### PR TITLE
Do not require feature=std for PublicKey::from_secret

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -657,7 +657,6 @@ impl PublicKey {
     }
 
     /// Derive this public key from its corresponding `SecretKey`.
-    #[cfg(feature = "std")]
     #[allow(unused_assignments)]
     pub fn from_secret<D>(secret_key: &SecretKey) -> PublicKey
             where D: Digest<OutputSize = U64> + Default {


### PR DESCRIPTION
In my use case I generate a secret key at one point in time, and then have to generate a corresponding public key later. The 0.5.0 version of ed25519-dalek has a leftover `feature="std"` requirement that's no longer needed.