### PR TITLE
Upgrade to rand 0.5 (fixes #23)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.4"
+version = "0.5"
 
 [dependencies.digest]
 version = "^0.7"

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -13,7 +13,7 @@
 use core::fmt::{Debug};
 
 #[cfg(feature = "std")]
-use rand::Rng;
+use rand::{CryptoRng, RngCore, OsRng};
 
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
@@ -61,6 +61,12 @@ const EXPANDED_SECRET_KEY_NONCE_LENGTH: usize = 32;
 
 /// The length of an "expanded" curve25519 EdDSA key, `ExpandedSecretKey`, in bytes.
 pub const EXPANDED_SECRET_KEY_LENGTH: usize = EXPANDED_SECRET_KEY_KEY_LENGTH + EXPANDED_SECRET_KEY_NONCE_LENGTH;
+
+/// Random number generator trait (bounded on the `CryptoRng` marker trait)
+#[cfg(feature = "std")]
+pub trait Rng: CryptoRng + RngCore {}
+#[cfg(feature = "std")]
+impl Rng for OsRng {}
 
 /// An EdDSA signature.
 ///


### PR DESCRIPTION
This switches `Keypair::generate` from a trait object to an explicit type parameter, which unfortunately I think is unavoidable given the new `rand` API.

## Alternatives Considered

### Bounded trait object

Doesn't work 😢 

```
error[E0225]: only auto traits can be used as additional traits in a trait object
   --> src/ed25519.rs:313:47
    |
313 |     pub fn generate(csprng: &mut (CryptoRng + RngCore)) -> SecretKey {
    |                                               ^^^^^^^ non-auto additional trait
```

### Phantom data parameter on `Keypair`

This is probably still worth considering, although it's a bit awkward. The RNG to use in conjunction with `::generate` could be provided as a type parameter on `struct Keypair` itself, which would allow supplying a default (i.e `struct Keypair<R: CryptoRng + RngCore = OsRng>`), but seems a bit awkward.

I'm still confused why `CryptoRng` is not defined as `CryptoRng: RngCore` in `rand`. At one point I think I figured out why but I have since forgotten...