### PR TITLE
Make `verify` return a `Result`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 version = "0.18"
 default-features = false
 
-[dependencies.subtle]
-version = "0.6"
-default-features = false
-
 [dependencies.rand]
 version = "0.5"
 default-features = false
@@ -59,8 +55,8 @@ harness = false
 [features]
 default = ["std", "u64_backend"]
 # We don't add "rand/std" here because it would enable a bunch of Fuchsia dependencies.
-std = ["subtle/std", "curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly", "subtle/nightly", "rand/nightly"]
+std = ["curve25519-dalek/std"]
+nightly = ["curve25519-dalek/nightly", "rand/nightly"]
 asm = ["sha2/asm"]
 yolocrypto = ["curve25519-dalek/yolocrypto"]
 u64_backend = ["curve25519-dalek/u64_backend"]

--- a/README.md
+++ b/README.md
@@ -55,12 +55,9 @@ nanoseconds to cycles per second on a 2591 Mhz CPU, that's 237660 cycles for
 verification and 102523 for signing, which for signing is competitive
 with optimised assembly versions.
 
-Additionally, if you're on the Rust nightly channel, be sure to build with
-`cargo build --features="nightly"` which enables more secure compiler
-optimisation protections in the
-[subtle](https://github.com/dalek-cryptography/subtle) crate.  Additionally, if
-you're using a CSPRNG from the `rand` crate, the `nightly` feature will enable
-`u128`/`i128` features there, resulting in potentially faster performance.
+Additionally, if you're using a CSPRNG from the `rand` crate, the `nightly`
+feature will enable `u128`/`i128` features there, resulting in potentially
+faster performance.
 
 Additionally, thanks to Rust, this implementation has both type and memory
 safety.  It's also easily readable by a much larger set of people than those who

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,7 @@
 //! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
 //! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
 //! # let signature: Signature = keypair.sign::<Sha512>(message);
-//! let verified: bool = keypair.verify::<Sha512>(message, &signature);
-//!
-//! assert!(verified);
+//! assert!(keypair.verify::<Sha512>(message, &signature).is_ok());
 //! # }
 //! ```
 //!
@@ -105,9 +103,7 @@
 //! # let signature: Signature = keypair.sign::<Sha512>(message);
 //!
 //! let public_key: PublicKey = keypair.public;
-//! let verified: bool = public_key.verify::<Sha512>(message, &signature);
-//!
-//! assert!(verified);
+//! assert!(public_key.verify::<Sha512>(message, &signature).is_ok());
 //! # }
 //! ```
 //!
@@ -133,7 +129,6 @@
 //! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
 //! # let signature: Signature = keypair.sign::<Sha512>(message);
 //! # let public_key: PublicKey = keypair.public;
-//! # let verified: bool = public_key.verify::<Sha512>(message, &signature);
 //!
 //! let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = public_key.to_bytes();
 //! let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair.secret.to_bytes();
@@ -150,9 +145,9 @@
 //! # extern crate ed25519_dalek;
 //! # use rand::{Rng, ChaChaRng, SeedableRng};
 //! # use sha2::Sha512;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey, DecodingError};
+//! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), DecodingError> {
+//! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), SignatureError> {
 //! # let mut csprng: ChaChaRng = ChaChaRng::from_seed([0u8; 32]);
 //! # let keypair_orig: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
 //! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
@@ -267,7 +262,6 @@
 extern crate curve25519_dalek;
 extern crate generic_array;
 extern crate digest;
-extern crate subtle;
 extern crate failure;
 extern crate rand;
 


### PR DESCRIPTION
This also simplifies the verification logic.  Because the verification check
happens in variable time, we don't need to do a constant-time eq check at the
end, so we can drop the `subtle` dependency entirely.