### PR TITLE
Revert "Add AsRef instances for PublicKey and SecretKey"

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -183,12 +183,6 @@ impl Drop for SecretKey {
     }
 }
 
-impl AsRef<[u8]> for SecretKey {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
 impl SecretKey {
     /// Expand this `SecretKey` into an `ExpandedSecretKey`.
     pub fn expand<D>(&self) -> ExpandedSecretKey
@@ -718,12 +712,6 @@ pub struct PublicKey(pub (crate) CompressedEdwardsY);
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "PublicKey( CompressedEdwardsY( {:?} ))", self.0)
-    }
-}
-
-impl AsRef<[u8]> for PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
     }
 }
 


### PR DESCRIPTION
Reverts dalek-cryptography/ed25519-dalek#49 which was accidentally merged onto `master` instead of `develop`.

