### PR TITLE
Hardcode use of sha2::Sha512 in most cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ optional = true
 
 [dependencies.sha2]
 version = "^0.8"
-optional = true
+default-features = false
 
 [dependencies.failure]
 version = "^0.1.1"
@@ -40,7 +40,6 @@ version = "0.2"
 
 [dev-dependencies]
 hex = "^0.3"
-sha2 = "^0.8"
 bincode = "^0.9"
 criterion = "0.2"
 
@@ -51,7 +50,7 @@ harness = false
 [features]
 default = ["std", "u64_backend"]
 # We don't add "rand/std" here because it would enable a bunch of Fuchsia dependencies.
-std = ["curve25519-dalek/std", "rand/std"]
+std = ["curve25519-dalek/std", "rand/std", "sha2/std"]
 alloc = ["curve25519-dalek/alloc"]
 nightly = ["curve25519-dalek/nightly", "rand/nightly", "clear_on_drop/nightly"]
 asm = ["sha2/asm"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,28 +15,25 @@
 //!
 //! First, we need to generate a `Keypair`, which includes both public and
 //! secret halves of an asymmetric key.  To do so, we need a cryptographically
-//! secure pseudorandom number generator (CSPRNG), and a hash function which
-//! has 512 bits of output.  For this example, we'll use the operating
-//! system's builtin PRNG and SHA-512 to generate a keypair:
+//! secure pseudorandom number generator (CSPRNG). For this example, we'll use
+//! the operating system's builtin PRNG:
 //!
 //! ```
 //! extern crate rand;
-//! extern crate sha2;
 //! extern crate ed25519_dalek;
 //!
-//! # #[cfg(all(feature = "std", feature = "sha2"))]
+//! # #[cfg(feature = "std")]
 //! # fn main() {
 //! use rand::Rng;
 //! use rand::OsRng;
-//! use sha2::Sha512;
 //! use ed25519_dalek::Keypair;
 //! use ed25519_dalek::Signature;
 //!
 //! let mut csprng: OsRng = OsRng::new().unwrap();
-//! let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng); // The `_` can be the type of `csprng`
+//! let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # }
 //! #
-//! # #[cfg(any(not(feature = "std"), not(feature = "sha2")))]
+//! # #[cfg(not(feature = "std"))]
 //! # fn main() { }
 //! ```
 //!
@@ -44,18 +41,16 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::Keypair;
 //! # use ed25519_dalek::Signature;
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! let signature: Signature = keypair.sign::<Sha512>(message);
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! let signature: Signature = keypair.sign(message);
 //! # }
 //! ```
 //!
@@ -64,19 +59,17 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::Keypair;
 //! # use ed25519_dalek::Signature;
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature: Signature = keypair.sign::<Sha512>(message);
-//! assert!(keypair.verify::<Sha512>(message, &signature).is_ok());
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature: Signature = keypair.sign(message);
+//! assert!(keypair.verify(message, &signature).is_ok());
 //! # }
 //! ```
 //!
@@ -85,22 +78,20 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::Keypair;
 //! # use ed25519_dalek::Signature;
 //! use ed25519_dalek::PublicKey;
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature: Signature = keypair.sign::<Sha512>(message);
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature: Signature = keypair.sign(message);
 //!
 //! let public_key: PublicKey = keypair.public;
-//! assert!(public_key.verify::<Sha512>(message, &signature).is_ok());
+//! assert!(public_key.verify(message, &signature).is_ok());
 //! # }
 //! ```
 //!
@@ -114,18 +105,16 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::{Keypair, Signature, PublicKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature: Signature = keypair.sign::<Sha512>(message);
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
 //!
 //! let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = public_key.to_bytes();
@@ -139,18 +128,16 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), SignatureError> {
 //! # let mut csprng = thread_rng();
-//! # let keypair_orig: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature_orig: Signature = keypair_orig.sign::<Sha512>(message);
+//! # let keypair_orig: Keypair = Keypair::generate(&mut csprng);
+//! # let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature_orig: Signature = keypair_orig.sign(message);
 //! # let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = keypair_orig.public.to_bytes();
 //! # let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair_orig.secret.to_bytes();
 //! # let keypair_bytes:    [u8; KEYPAIR_LENGTH]    = keypair_orig.to_bytes();
@@ -183,7 +170,6 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
 //! extern crate serde;
@@ -194,15 +180,14 @@
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::{Keypair, Signature, PublicKey};
 //! use bincode::{serialize, Infinite};
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature: Signature = keypair.sign::<Sha512>(message);
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
-//! # let verified: bool = public_key.verify::<Sha512>(message, &signature).is_ok();
+//! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //!
 //! let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
 //! let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
@@ -216,7 +201,6 @@
 //!
 //! ```
 //! # extern crate rand;
-//! # extern crate sha2;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
 //! # extern crate serde;
@@ -227,17 +211,16 @@
 //! # fn main() {
 //! # use rand::Rng;
 //! # use rand::thread_rng;
-//! # use sha2::Sha512;
 //! # use ed25519_dalek::{Keypair, Signature, PublicKey};
 //! # use bincode::{serialize, Infinite};
 //! use bincode::{deserialize};
 //!
 //! # let mut csprng = thread_rng();
-//! # let keypair: Keypair = Keypair::generate::<Sha512, _>(&mut csprng);
-//! let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
-//! # let signature: Signature = keypair.sign::<Sha512>(message);
+//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! let message: &[u8] = b"This is a test of the tsunami alert system.";
+//! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
-//! # let verified: bool = public_key.verify::<Sha512>(message, &signature).is_ok();
+//! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //! # let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
 //! # let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
 //! let decoded_public_key: PublicKey = deserialize(&encoded_public_key).unwrap();
@@ -246,7 +229,7 @@
 //! # assert_eq!(public_key, decoded_public_key);
 //! # assert_eq!(signature, decoded_signature);
 //! #
-//! let verified: bool = decoded_public_key.verify::<Sha512>(&message, &decoded_signature).is_ok();
+//! let verified: bool = decoded_public_key.verify(&message, &decoded_signature).is_ok();
 //!
 //! assert!(verified);
 //! # }
@@ -267,7 +250,6 @@ extern crate rand;
 #[macro_use]
 extern crate std;
 
-#[cfg(any(test, feature = "sha2"))]
 extern crate sha2;
 
 #[cfg(test)]


### PR DESCRIPTION
This implements https://github.com/dalek-cryptography/ed25519-dalek/issues/64

You can still choose the "prehash" algorithm, as long as it has 64 bytes of
output.  Otherwise, everything is hardcoded to use sha2::Sha512.  To use a
different implementation you'll need a [patch.crates-io] section in cargo
config.