### PR TITLE
Use provided `Digest` in `_prehashed` functions 

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -361,7 +361,7 @@ impl Keypair {
         context: Option<&'static [u8]>,
     ) -> Signature
     where
-        D: Digest<OutputSize = U64>,
+        D: Digest<OutputSize = U64> + Default,
     {
         let expanded: ExpandedSecretKey = (&self.secret).into(); // xxx thanks i hate this
 
@@ -441,7 +441,7 @@ impl Keypair {
         signature: &Signature,
     ) -> Result<(), SignatureError>
     where
-        D: Digest<OutputSize = U64>,
+        D: Digest<OutputSize = U64> + Default,
     {
         self.public.verify_prehashed(prehashed_message, context, signature)
     }

--- a/src/public.rs
+++ b/src/public.rs
@@ -216,7 +216,7 @@ impl PublicKey {
         signature: &Signature,
     ) -> Result<(), SignatureError>
     where
-        D: Digest<OutputSize = U64> + Digest,
+        D: Digest<OutputSize = U64> + Digest + Default,
     {
         let mut h: D = D::new();
         let R: EdwardsPoint;

--- a/src/public.rs
+++ b/src/public.rs
@@ -216,9 +216,9 @@ impl PublicKey {
         signature: &Signature,
     ) -> Result<(), SignatureError>
     where
-        D: Digest<OutputSize = U64>,
+        D: Digest<OutputSize = U64> + Digest,
     {
-        let mut h: Sha512 = Sha512::default();
+        let mut h: D = D::new();
         let R: EdwardsPoint;
         let k: Scalar;
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -469,9 +469,9 @@ impl ExpandedSecretKey {
         context: Option<&'static [u8]>,
     ) -> Signature
     where
-        D: Digest<OutputSize = U64>,
+        D: Digest<OutputSize = U64> + Default,
     {
-        let mut h: Sha512;
+        let mut h: D;
         let mut prehash: [u8; 64] = [0u8; 64];
         let R: CompressedEdwardsY;
         let r: Scalar;
@@ -499,7 +499,7 @@ impl ExpandedSecretKey {
         //
         // This is a really fucking stupid bandaid, and the damned scheme is
         // still bleeding from malleability, for fuck's sake.
-        h = Sha512::new()
+        h = D::new()
             .chain(b"SigEd25519 no Ed25519 collisions")
             .chain(&[1]) // Ed25519ph
             .chain(&[ctx_len])
@@ -510,7 +510,7 @@ impl ExpandedSecretKey {
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
-        h = Sha512::new()
+        h = D::new()
             .chain(b"SigEd25519 no Ed25519 collisions")
             .chain(&[1]) // Ed25519ph
             .chain(&[ctx_len])


### PR DESCRIPTION
Wasn't this the intention? Otherwise - what's the point of taking prehashed image a `Digest`. Just let to user pass the result as an array, and don't bother with the bounds.

Another thing is - I'm surprised that normal `verify` is not a special case of `verify_prehashed`. `verify_prehashed` adds some custom prefixed header, and does  hash of a hash instead of the hash of the message.

Seems like introducing special-cases and making interoperability harder.

