### PR TITLE
Implement plain custom digest functions

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -254,6 +254,21 @@ impl Keypair {
         Keypair{ public: pk, secret: sk }
     }
 
+    /// Generate keypair using custom `Digest`
+    pub fn generate_with_digest<R, D>(csprng: &mut R) -> Keypair
+    where
+        R: CryptoRng + Rng,
+        D: Digest<OutputSize = U64> + Default,
+    {
+        let sk: SecretKey = SecretKey::generate(csprng);
+        let pk = PublicKey::from_secret_with_digest::<D>(&sk);
+
+        Keypair {
+            public: pk,
+            secret: sk,
+        }
+    }
+
     /// Sign a message with this keypair's secret key.
     pub fn sign(&self, message: &[u8]) -> Signature {
         let expanded: ExpandedSecretKey = (&self.secret).into();
@@ -264,9 +279,9 @@ impl Keypair {
     /// Sign a message with this keypair's secret key using custom digest algorithm.
     pub fn sign_with_digest<D>(&self, message: &[u8]) -> Signature
     where
-        D: Digest<OutputSize = U64> + Digest + Default
+        D: Digest<OutputSize = U64> + Digest + Default,
     {
-        let expanded: ExpandedSecretKey = (&self.secret).into();
+        let expanded = ExpandedSecretKey::from_secret_with_digest::<D>(&self.secret);
 
         expanded.sign_with_digest::<D>(&message, &self.public)
     }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -261,6 +261,16 @@ impl Keypair {
         expanded.sign(&message, &self.public)
     }
 
+    /// Sign a message with this keypair's secret key using custom digest algorithm.
+    pub fn sign_with_digest<D>(&self, message: &[u8]) -> Signature
+    where
+        D: Digest<OutputSize = U64> + Digest + Default
+    {
+        let expanded: ExpandedSecretKey = (&self.secret).into();
+
+        expanded.sign_with_digest::<D>(&message, &self.public)
+    }
+
     /// Sign a `prehashed_message` with this `Keypair` using the
     /// Ed25519ph algorithm defined in [RFC8032 §5.1][rfc8032].
     ///

--- a/src/public.rs
+++ b/src/public.rs
@@ -261,6 +261,23 @@ impl PublicKey {
             Err(SignatureError(InternalError::VerifyError))
         }
     }
+
+    /// Derive this public key from its corresponding `SecretKey`.
+    #[allow(unused_assignments)]
+    pub fn from_secret_with_digest<D>(secret_key: &SecretKey) -> Self
+        where D: Digest<OutputSize = U64> + Default
+    {
+        let mut h:    D = D::default();
+        let mut hash:   [u8; 64] = [0u8; 64];
+        let mut digest: [u8; 32] = [0u8; 32];
+
+        h.input(secret_key.as_bytes());
+        hash.copy_from_slice(h.result().as_slice());
+
+        digest.copy_from_slice(&hash[..32]);
+
+        Self::mangle_scalar_bits_and_multiply_by_basepoint_to_produce_public_key(&mut digest)
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/public.rs
+++ b/src/public.rs
@@ -171,7 +171,24 @@ impl PublicKey {
         signature: &Signature
     ) -> Result<(), SignatureError>
     {
-        let mut h: Sha512 = Sha512::new();
+        self.verify_with_digest::<Sha512>(message, signature)
+    }
+
+    /// Verify a signature on a message with this keypair's public key
+    /// using custom Digest algorithm.
+    ///
+    /// # Return
+    ///
+    /// Returns `Ok(())` if the signature is valid, and `Err` otherwise.
+    #[allow(non_snake_case)]
+    pub fn verify_with_digest<D>(
+        &self,
+        message: &[u8],
+        signature: &Signature
+    ) -> Result<(), SignatureError>
+        where D: Digest<OutputSize = U64> + Default
+    {
+        let mut h: D = D::new();
         let R: EdwardsPoint;
         let k: Scalar;
         let minus_A: EdwardsPoint = -self.1;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -420,7 +420,17 @@ impl ExpandedSecretKey {
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
     pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> Signature {
-        let mut h: Sha512 = Sha512::new();
+        self.sign_with_digest::<Sha512>(message, public_key)
+    }
+
+    /// Sign a message with this `ExpandedSecretKey` using custom
+    /// digest algorithm.
+    #[allow(non_snake_case)]
+    pub fn sign_with_digest<D>(&self, message: &[u8], public_key: &PublicKey) -> Signature
+    where
+        D: Digest<OutputSize = U64> + Digest + Default
+    {
+        let mut h: D = D::new();
         let R: CompressedEdwardsY;
         let r: Scalar;
         let s: Scalar;
@@ -432,7 +442,7 @@ impl ExpandedSecretKey {
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
-        h = Sha512::new();
+        h = D::new();
         h.input(R.as_bytes());
         h.input(public_key.as_bytes());
         h.input(&message);


### PR DESCRIPTION
Any chance this could be supported, at least temporarily, for backward-compatibility with how things previously worked?