### PR TITLE
Impl Hash, Ord and PartialOrd for PublicKey and Signature

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -9,7 +9,12 @@
 
 //! ed25519 public keys.
 
+use core::cmp::Ord;
+use core::cmp::Ordering;
+use core::cmp::PartialOrd;
 use core::fmt::Debug;
+use core::hash::Hash;
+use core::hash::Hasher;
 
 use curve25519_dalek::constants;
 use curve25519_dalek::digest::generic_array::typenum::U64;
@@ -47,6 +52,24 @@ impl Debug for PublicKey {
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_bytes().hash(state)
+    }
+}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        self.0.as_bytes().cmp(rhs.0.as_bytes())
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -9,7 +9,12 @@
 
 //! An ed25519 signature.
 
+use core::cmp::Ord;
+use core::cmp::Ordering;
+use core::cmp::PartialOrd;
 use core::fmt::Debug;
+use core::hash::Hash;
+use core::hash::Hasher;
 
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
@@ -68,6 +73,27 @@ impl Clone for Signature {
 impl Debug for Signature {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "Signature( R: {:?}, s: {:?} )", &self.R, &self.s)
+    }
+}
+
+impl Hash for Signature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.R.as_bytes().hash(state);
+        self.s.as_bytes().hash(state);
+    }
+}
+
+impl PartialOrd for Signature {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+    }
+}
+
+impl Ord for Signature {
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        self.R.as_bytes().cmp(rhs.R.as_bytes()).then_with(|| {
+            self.s.as_bytes().cmp(rhs.s.as_bytes())
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds implementations of `Ord`, `PartialOrd` and `Hash` to `PublicKey` and `Signature`. The motivation behind this change is to allow using `PublicKey` and `Signature` as keys in `HashMap` / `HashSet` / `BTreeMap` and `BTreeSet` and also to support deriving those traits on types which contain `PublicKey` and/or `Signature` members.