### PR TITLE
Use `default-features = false` with `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ curve25519-dalek = { version = "2", default-features = false }
 merlin = { version = "1", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 sha2 = { version = "0.8", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
It doesn't appear to me that ed25519-dalek crate needs any of the std-related
features of serde. But it turns them on anyways because it doesn't put
`default-features = false`.

This breaks no_std builds. Otherwise I think we could use 1.0.0-pre3 in mobilecoin.
I'm going to test this revision in our build and see if I'm right. I don't think
this is a breaking change from dalek's point of view.