### PR TITLE
Fixup rand

### DIFF
--- a/src/secret.rs
+++ b/src/secret.rs
@@ -19,6 +19,7 @@ use curve25519_dalek::digest::Digest;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
 
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
 use sha2::Sha512;


### PR DESCRIPTION
I tried to uprev our version of ed25519-dalek but I ran into two issues:

1: missing `#[cfg(feature = rand)]` in `secret.rs` ( I think this is a further case of #108 ), we are building with these features:

```
..., default-features = false, features = ["alloc", "nightly", "serde", "u64_backend"] }
```

2: we lost `Default` trait on `SecretKey`, I don't know if that was intentional API change? but atm we are using that anyways, please lmk! thank you