### PR TITLE
Use `ed25519` + `signature` interop crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ features = ["nightly", "batch"]
 
 [dependencies]
 curve25519-dalek = { version = "2", default-features = false }
+ed25519 = { version = "1", default-features = false }
 merlin = { version = "1", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
+serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 sha2 = { version = "0.8", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
@@ -45,9 +46,10 @@ harness = false
 
 [features]
 default = ["std", "u64_backend"]
-std = ["curve25519-dalek/std", "serde/std", "sha2/std", "rand/std"]
+std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek/nightly", "rand/nightly"]
+serde = ["serde_crate", "ed25519/serde"]
 batch = ["merlin", "rand"]
 # This feature enables deterministic batch verification.
 batch_deterministic = ["merlin", "rand", "rand_core"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -80,18 +80,16 @@ impl Error for InternalError { }
 ///   only be constructed from 255-bit integers.)
 ///
 /// * Failure of a signature to satisfy the verification equation.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
-pub struct SignatureError(pub(crate) InternalError);
+pub type SignatureError = ed25519::signature::Error;
 
-impl Display for SignatureError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+impl From<InternalError> for SignatureError {
+    #[cfg(not(feature = "std"))]
+    fn from(_err: InternalError) -> SignatureError {
+        SignatureError::new()
     }
-}
 
-#[cfg(feature = "std")]
-impl Error for SignatureError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.0)
+    #[cfg(feature = "std")]
+    fn from(err: InternalError) -> SignatureError {
+        SignatureError::from_source(err)
     }
 }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -9,8 +9,6 @@
 
 //! ed25519 keypairs.
 
-use core::default::Default;
-
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
@@ -26,13 +24,12 @@ pub use sha2::Sha512;
 use curve25519_dalek::digest::generic_array::typenum::U64;
 pub use curve25519_dalek::digest::Digest;
 
-#[cfg(all(feature = "batch", any(feature = "std", feature = "alloc")))]
-pub use crate::batch::*;
-pub use crate::constants::*;
-pub use crate::errors::*;
-pub use crate::public::*;
-pub use crate::secret::*;
-pub use crate::signature::*;
+use ed25519::signature::{Signer, Verifier};
+
+use crate::constants::*;
+use crate::errors::*;
+use crate::public::*;
+use crate::secret::*;
 
 /// An ed25519 keypair.
 #[derive(Debug)]
@@ -82,10 +79,10 @@ impl Keypair {
     /// is an `SignatureError` describing the error that occurred.
     pub fn from_bytes<'a>(bytes: &'a [u8]) -> Result<Keypair, SignatureError> {
         if bytes.len() != KEYPAIR_LENGTH {
-            return Err(SignatureError(InternalError::BytesLengthError {
+            return Err(InternalError::BytesLengthError {
                 name: "Keypair",
                 length: KEYPAIR_LENGTH,
-            }));
+            }.into());
         }
         let secret = SecretKey::from_bytes(&bytes[..SECRET_KEY_LENGTH])?;
         let public = PublicKey::from_bytes(&bytes[SECRET_KEY_LENGTH..])?;
@@ -134,13 +131,6 @@ impl Keypair {
         let pk: PublicKey = (&sk).into();
 
         Keypair{ public: pk, secret: sk }
-    }
-
-    /// Sign a message with this keypair's secret key.
-    pub fn sign(&self, message: &[u8]) -> Signature {
-        let expanded: ExpandedSecretKey = (&self.secret).into();
-
-        expanded.sign(&message, &self.public)
     }
 
     /// Sign a `prehashed_message` with this `Keypair` using the
@@ -241,20 +231,20 @@ impl Keypair {
         &self,
         prehashed_message: D,
         context: Option<&[u8]>,
-    ) -> Signature
+    ) -> ed25519::Signature
     where
         D: Digest<OutputSize = U64>,
     {
         let expanded: ExpandedSecretKey = (&self.secret).into(); // xxx thanks i hate this
 
-        expanded.sign_prehashed(prehashed_message, &self.public, context)
+        expanded.sign_prehashed(prehashed_message, &self.public, context).into()
     }
 
     /// Verify a signature on a message with this keypair's public key.
     pub fn verify(
         &self,
         message: &[u8],
-        signature: &Signature
+        signature: &ed25519::Signature
     ) -> Result<(), SignatureError>
     {
         self.public.verify(message, signature)
@@ -320,7 +310,7 @@ impl Keypair {
         &self,
         prehashed_message: D,
         context: Option<&[u8]>,
-        signature: &Signature,
+        signature: &ed25519::Signature,
     ) -> Result<(), SignatureError>
     where
         D: Digest<OutputSize = U64>,
@@ -394,10 +384,25 @@ impl Keypair {
     pub fn verify_strict(
         &self,
         message: &[u8],
-        signature: &Signature,
+        signature: &ed25519::Signature,
     ) -> Result<(), SignatureError>
     {
         self.public.verify_strict(message, signature)
+    }
+}
+
+impl Signer<ed25519::Signature> for Keypair {
+    /// Sign a message with this keypair's secret key.
+    fn try_sign(&self, message: &[u8]) -> Result<ed25519::Signature, SignatureError> {
+        let expanded: ExpandedSecretKey = (&self.secret).into();
+        Ok(expanded.sign(&message, &self.public).into())
+    }
+}
+
+impl Verifier<ed25519::Signature> for Keypair {
+    /// Verify a signature on a message with this keypair's public key.
+    fn verify(&self, message: &[u8], signature: &ed25519::Signature) -> Result<(), SignatureError> {
+        self.public.verify(message, signature)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@
 //! # fn main() {
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::Keypair;
-//! # use ed25519_dalek::Signature;
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! use ed25519_dalek::{Signature, Signer};
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! let signature: Signature = keypair.sign(message);
 //! # }
@@ -60,12 +60,12 @@
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::rngs::OsRng;
-//! # use ed25519_dalek::Keypair;
-//! # use ed25519_dalek::Signature;
+//! # use ed25519_dalek::{Keypair, Signature, Signer};
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
+//! use ed25519_dalek::Verifier;
 //! assert!(keypair.verify(message, &signature).is_ok());
 //! # }
 //! ```
@@ -80,7 +80,8 @@
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::Keypair;
 //! # use ed25519_dalek::Signature;
-//! use ed25519_dalek::PublicKey;
+//! # use ed25519_dalek::Signer;
+//! use ed25519_dalek::{PublicKey, Verifier};
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -104,7 +105,7 @@
 //! # extern crate ed25519_dalek;
 //! # fn main() {
 //! # use rand::rngs::OsRng;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey};
+//! # use ed25519_dalek::{Keypair, Signature, Signer, PublicKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
@@ -124,8 +125,9 @@
 //! ```
 //! # extern crate rand;
 //! # extern crate ed25519_dalek;
+//! # use std::convert::TryFrom;
 //! # use rand::rngs::OsRng;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey, SignatureError};
+//! # use ed25519_dalek::{Keypair, Signature, Signer, PublicKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), SignatureError> {
 //! # let mut csprng = OsRng{};
@@ -140,7 +142,7 @@
 //! let public_key: PublicKey = PublicKey::from_bytes(&public_key_bytes)?;
 //! let secret_key: SecretKey = SecretKey::from_bytes(&secret_key_bytes)?;
 //! let keypair:    Keypair   = Keypair::from_bytes(&keypair_bytes)?;
-//! let signature:  Signature = Signature::from_bytes(&signature_bytes)?;
+//! let signature:  Signature = Signature::try_from(&signature_bytes[..])?;
 //! #
 //! # Ok((secret_key, public_key, keypair, signature))
 //! # }
@@ -166,14 +168,14 @@
 //! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
-//! extern crate serde;
+//! # extern crate serde_crate as serde;
 //! # #[cfg(feature = "serde")]
-//! extern crate bincode;
+//! # extern crate bincode;
 //!
 //! # #[cfg(feature = "serde")]
 //! # fn main() {
 //! # use rand::rngs::OsRng;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey};
+//! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
 //! use bincode::{serialize, Infinite};
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
@@ -196,16 +198,16 @@
 //! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
-//! # extern crate serde;
+//! # extern crate serde_crate as serde;
 //! # #[cfg(feature = "serde")]
 //! # extern crate bincode;
 //! #
 //! # #[cfg(feature = "serde")]
 //! # fn main() {
 //! # use rand::rngs::OsRng;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey};
+//! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
 //! # use bincode::{serialize, Infinite};
-//! use bincode::{deserialize};
+//! use bincode::deserialize;
 //!
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
@@ -237,6 +239,8 @@
 #[macro_use]
 extern crate std;
 
+pub extern crate ed25519;
+
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 extern crate curve25519_dalek;
@@ -245,20 +249,29 @@ extern crate merlin;
 #[cfg(any(feature = "batch", feature = "std", feature = "alloc", test))]
 extern crate rand;
 #[cfg(feature = "serde")]
-extern crate serde;
+extern crate serde_crate as serde;
 extern crate sha2;
 extern crate zeroize;
 
 #[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
 mod batch;
 mod constants;
-mod ed25519;
+mod keypair;
 mod errors;
 mod public;
 mod secret;
 mod signature;
 
-// Export everything public in ed25519.
-pub use crate::ed25519::*;
+pub use curve25519_dalek::digest::Digest;
+
 #[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
 pub use crate::batch::*;
+pub use crate::constants::*;
+pub use crate::errors::*;
+pub use crate::keypair::*;
+pub use crate::public::*;
+pub use crate::secret::*;
+
+// Re-export the `Signer` and `Verifier` traits from the `signature` crate
+pub use ed25519::signature::{Signer, Verifier};
+pub use ed25519::Signature;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -106,10 +106,10 @@ impl SecretKey {
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey, SignatureError> {
         if bytes.len() != SECRET_KEY_LENGTH {
-            return Err(SignatureError(InternalError::BytesLengthError {
+            return Err(InternalError::BytesLengthError {
                 name: "SecretKey",
                 length: SECRET_KEY_LENGTH,
-            }));
+            }.into());
         }
         let mut bits: [u8; 32] = [0u8; 32];
         bits.copy_from_slice(&bytes[..32]);
@@ -383,10 +383,10 @@ impl ExpandedSecretKey {
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<ExpandedSecretKey, SignatureError> {
         if bytes.len() != EXPANDED_SECRET_KEY_LENGTH {
-            return Err(SignatureError(InternalError::BytesLengthError {
+            return Err(InternalError::BytesLengthError {
                 name: "ExpandedSecretKey",
                 length: EXPANDED_SECRET_KEY_LENGTH,
-            }));
+            }.into());
         }
         let mut lower: [u8; 32] = [0u8; 32];
         let mut upper: [u8; 32] = [0u8; 32];
@@ -402,7 +402,7 @@ impl ExpandedSecretKey {
 
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
-    pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> Signature {
+    pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
         let mut h: Sha512 = Sha512::new();
         let R: CompressedEdwardsY;
         let r: Scalar;
@@ -423,7 +423,7 @@ impl ExpandedSecretKey {
         k = Scalar::from_hash(h);
         s = &(&k * &self.key) + &r;
 
-        Signature { R, s }
+        InternalSignature { R, s }.into()
     }
 
     /// Sign a `prehashed_message` with this `ExpandedSecretKey` using the
@@ -450,7 +450,7 @@ impl ExpandedSecretKey {
         prehashed_message: D,
         public_key: &PublicKey,
         context: Option<&'a [u8]>,
-    ) -> Signature
+    ) -> ed25519::Signature
     where
         D: Digest<OutputSize = U64>,
     {
@@ -505,7 +505,7 @@ impl ExpandedSecretKey {
         k = Scalar::from_hash(h);
         s = &(&k * &self.key) + &r;
 
-        Signature { R, s }
+        InternalSignature { R, s }.into()
     }
 }
 

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -24,6 +24,8 @@ use sha2::Sha512;
 
 #[cfg(test)]
 mod vectors {
+    use ed25519::signature::Signature as _;
+
     use std::io::BufReader;
     use std::io::BufRead;
     use std::fs::File;
@@ -219,6 +221,8 @@ mod serialisation {
 
     use self::bincode::{serialize, serialized_size, deserialize, Infinite};
 
+    use ed25519::signature::Signature as _;
+
     static PUBLIC_KEY_BYTES: [u8; PUBLIC_KEY_LENGTH] = [
         130, 039, 155, 015, 062, 076, 188, 063,
         124, 122, 026, 251, 233, 253, 225, 220,
@@ -281,7 +285,7 @@ mod serialisation {
     #[test]
     fn serialize_signature_size() {
         let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
-        assert_eq!(serialized_size(&signature) as usize, 72); // These sizes are specific to bincode==1.0.1
+        assert_eq!(serialized_size(&signature) as usize, 64); // These sizes are specific to bincode==1.0.1
     }
 
     #[test]


### PR DESCRIPTION
(take 2: my first attempt was #102)

The `signature` crate provides `Signer` and `Verifier` traits generic over signature types:

https://github.com/RustCrypto/traits/tree/master/signature

There's presently an open call to stabilize the parts of its API needed by Ed25519 signatures and release a 1.0 version:

https://github.com/RustCrypto/traits/issues/78

The `ed25519` crate, based on the `signature` crate, provides an `ed25519::Signature` type which can be shared across multiple Ed25519 crates (e.g. it is also used by the `yubihsm` crate):

https://github.com/RustCrypto/signatures/tree/master/ed25519

This commit integrates the `ed25519::Signature` type, and changes the existing `sign` and `verify` methods (where applicable) to use the `Signer` and `Verifier` traits from the `signature` crate. Additionally, it replaces `SignatureError` with the `signature` crate's error type.

This has the drawback of requiring the `Signer` and/or `Verifier` traits are in scope in order to create and/or verify signatures, but with the benefit of supporting interoperability with other Ed25519 crates which also make use of these traits.