### PR TITLE
Updates the merlin dependency to ^2 and the correct repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["nightly", "batch"]
 [dependencies]
 clear_on_drop = { version = "0.2" }
 curve25519-dalek = { version = "2", default-features = false }
-merlin = { version = "1", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
+merlin = { version = "2", default-features = false, optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
This fixes the "batch" feature for 1.0.0-pre.3, see #126.

This may hint at a 1.0.0-pre.4 soon.

Tested by:
- creating an initial project (`cargo init`) in an empty directory,
- adding the following dependency line to the `Cargo.toml`:
```
ed25519-dalek = { git = "https://github.com/huitseeker/ed25519-dalek", branch = "update-merlin", features = ["batch"] }
```
- running a successful `cargo check`
- running `cargo tree` and checking the correct version of merlin is resolved:
https://gist.github.com/1023c8b2cf5a384599e929c92b136449
