### PR TITLE
Impl std::error::Error for SignatureError.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,3 +93,6 @@ impl From<InternalError> for SignatureError {
         SignatureError::from_source(err)
     }
 }
+
+#[cfg(feature = "std")]
+impl Error for SignatureError { }


### PR DESCRIPTION
Closes #114.