### PR TITLE
Fix ed25519ph context length error handling in sign_prehashed().

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,6 +41,8 @@ pub(crate) enum InternalError {
     ArrayLengthError{ name_a: &'static str, length_a: usize,
                       name_b: &'static str, length_b: usize,
                       name_c: &'static str, length_c: usize, },
+    /// An ed25519ph signature can only take up to 255 octets of context.
+    PrehashedContextLengthError,
 }
 
 impl Display for InternalError {
@@ -59,6 +61,8 @@ impl Display for InternalError {
                                              name_c: nc, length_c: lc, }
                 => write!(f, "Arrays must be the same length: {} has length {},
                               {} has length {}, {} has length {}.", na, la, nb, lb, nc, lc),
+            InternalError::PrehashedContextError
+                => write!(f, "An ed25519ph signature can only take up to 255 octets of context"),
         }
     }
 }


### PR DESCRIPTION
RFC8032 specifies that the context cannot be greater than 255 octets,
but in the previous implementation in ed25519-dalek, this error would
only be caught by a debug_assert.  This changes the sign_prehashed()
function to return a Result so that the error can be handled at
runtime and the library no longer allows misuse by creating signatures
that other libraries cannot handle.