### PR TITLE
Make `use rand::...` gated on `cfg(feature = "rand")`

### DIFF
--- a/src/secret.rs
+++ b/src/secret.rs
@@ -17,6 +17,7 @@ use curve25519_dalek::digest::Digest;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
 
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
 use sha2::Sha512;


### PR DESCRIPTION
This is no longer actively breaking our no_std build, but I think
it's still technically a minor bug, and further case of issue #108

This was https://github.com/dalek-cryptography/ed25519-dalek/pull/110
but that PR was very old and there were additional issues then which are moot now