### PR TITLE
Fix serde implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 
 [dev-dependencies]
 hex = "^0.4"
-bincode = "^0.9"
+bincode = "1.0"
 criterion = "0.3"
 rand = "0.7"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 [dev-dependencies]
 hex = "^0.4"
 bincode = "1.0"
+serde_json = "1.0"
 criterion = "0.3"
 rand = "0.7"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@
 //! # fn main() {
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
-//! use bincode::{serialize, Infinite};
+//! use bincode::serialize;
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -184,8 +184,8 @@
 //! # let public_key: PublicKey = keypair.public;
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //!
-//! let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
-//! let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
+//! let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
+//! let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
 //! # }
 //! # #[cfg(not(feature = "serde"))]
 //! # fn main() {}
@@ -206,7 +206,7 @@
 //! # fn main() {
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
-//! # use bincode::{serialize, Infinite};
+//! # use bincode::serialize;
 //! use bincode::deserialize;
 //!
 //! # let mut csprng = OsRng{};
@@ -215,8 +215,8 @@
 //! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
-//! # let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
-//! # let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
+//! # let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
+//! # let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
 //! let decoded_public_key: PublicKey = deserialize(&encoded_public_key).unwrap();
 //! let decoded_signature: Signature = deserialize(&encoded_signature).unwrap();
 //!

--- a/src/public.rs
+++ b/src/public.rs
@@ -26,8 +26,6 @@ pub use sha2::Sha512;
 #[cfg(feature = "serde")]
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serde")]
-use serde::de::Visitor;
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
 use serde::{Deserializer, Serializer};
@@ -362,7 +360,7 @@ impl Serialize for PublicKey {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(self.as_bytes())
+        self.to_bytes().serialize(serializer)
     }
 }
 
@@ -372,24 +370,7 @@ impl<'d> Deserialize<'d> for PublicKey {
     where
         D: Deserializer<'d>,
     {
-        struct PublicKeyVisitor;
-
-        impl<'d> Visitor<'d> for PublicKeyVisitor {
-            type Value = PublicKey;
-
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                formatter.write_str(
-                    "An ed25519 public key as a 32-byte compressed point, as specified in RFC8032",
-                )
-            }
-
-            fn visit_bytes<E>(self, bytes: &[u8]) -> Result<PublicKey, E>
-            where
-                E: SerdeError,
-            {
-                PublicKey::from_bytes(bytes).or(Err(SerdeError::invalid_length(bytes.len(), &self)))
-            }
-        }
-        deserializer.deserialize_bytes(PublicKeyVisitor)
+        let bytes = <[u8; PUBLIC_KEY_LENGTH]>::deserialize(deserializer)?;
+        PublicKey::from_bytes(&bytes[..]).map_err(SerdeError::custom)
     }
 }

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -308,7 +308,7 @@ mod serialisation {
         let encoded_secret_key: Vec<u8> = bincode::serialize(&secret_key).unwrap();
         let decoded_secret_key: SecretKey = bincode::deserialize(&encoded_secret_key).unwrap();
 
-        for i in 0..32 {
+        for i in 0..SECRET_KEY_LENGTH {
             assert_eq!(SECRET_KEY_BYTES[i], decoded_secret_key.as_bytes()[i]);
         }
     }
@@ -319,8 +319,30 @@ mod serialisation {
         let encoded_secret_key = serde_json::to_string(&secret_key).unwrap();
         let decoded_secret_key: SecretKey = serde_json::from_str(&encoded_secret_key).unwrap();
 
-        for i in 0..32 {
+        for i in 0..SECRET_KEY_LENGTH {
             assert_eq!(SECRET_KEY_BYTES[i], decoded_secret_key.as_bytes()[i]);
+        }
+    }
+
+    #[test]
+    fn serialize_deserialize_expanded_secret_key_bincode() {
+        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        let encoded_expanded_secret_key: Vec<u8> = bincode::serialize(&expanded_secret_key).unwrap();
+        let decoded_expanded_secret_key: ExpandedSecretKey = bincode::deserialize(&encoded_expanded_secret_key).unwrap();
+
+        for i in 0..EXPANDED_SECRET_KEY_LENGTH {
+            assert_eq!(expanded_secret_key.to_bytes()[i], decoded_expanded_secret_key.to_bytes()[i]);
+        }
+    }
+
+    #[test]
+    fn serialize_deserialize_expanded_secret_key_json() {
+        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        let encoded_expanded_secret_key = serde_json::to_string(&expanded_secret_key).unwrap();
+        let decoded_expanded_secret_key: ExpandedSecretKey = serde_json::from_str(&encoded_expanded_secret_key).unwrap();
+
+        for i in 0..EXPANDED_SECRET_KEY_LENGTH {
+            assert_eq!(expanded_secret_key.to_bytes()[i], decoded_expanded_secret_key.to_bytes()[i]);
         }
     }
 
@@ -330,7 +352,7 @@ mod serialisation {
         let encoded_keypair: Vec<u8> = bincode::serialize(&keypair).unwrap();
         let decoded_keypair: Keypair = bincode::deserialize(&encoded_keypair).unwrap();
 
-        for i in 0..64 {
+        for i in 0..KEYPAIR_LENGTH {
             assert_eq!(KEYPAIR_BYTES[i], decoded_keypair.to_bytes()[i]);
         }
     }
@@ -341,7 +363,7 @@ mod serialisation {
         let encoded_keypair = serde_json::to_string(&keypair).unwrap();
         let decoded_keypair: Keypair = serde_json::from_str(&encoded_keypair).unwrap();
 
-        for i in 0..64 {
+        for i in 0..KEYPAIR_LENGTH {
             assert_eq!(KEYPAIR_BYTES[i], decoded_keypair.to_bytes()[i]);
         }
     }
@@ -373,5 +395,17 @@ mod serialisation {
     fn serialize_secret_key_size() {
         let secret_key: SecretKey = SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap();
         assert_eq!(bincode::serialized_size(&secret_key).unwrap() as usize, SECRET_KEY_LENGTH);
+    }
+
+    #[test]
+    fn serialize_expanded_secret_key_size() {
+        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        assert_eq!(bincode::serialized_size(&expanded_secret_key).unwrap() as usize, EXPANDED_SECRET_KEY_LENGTH);
+    }
+
+    #[test]
+    fn serialize_keypair_size() {
+        let keypair = Keypair::from_bytes(&KEYPAIR_BYTES).unwrap();
+        assert_eq!(bincode::serialized_size(&keypair).unwrap() as usize, KEYPAIR_LENGTH);
     }
 }

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -230,9 +230,6 @@ struct Demo {
 mod serialisation {
     use super::*;
 
-    use self::bincode::{serialize, serialized_size, deserialize, Infinite};
-    use self::toml;
-
     use ed25519::signature::Signature as _;
 
     static PUBLIC_KEY_BYTES: [u8; PUBLIC_KEY_LENGTH] = [
@@ -269,29 +266,29 @@ mod serialisation {
         035, 056, 000, 074, 130, 168, 225, 071, ];
 
     #[test]
-    fn serialize_deserialize_signature() {
+    fn serialize_deserialize_signature_bincode() {
         let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
-        let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
-        let decoded_signature: Signature = deserialize(&encoded_signature).unwrap();
+        let encoded_signature: Vec<u8> = bincode::serialize(&signature).unwrap();
+        let decoded_signature: Signature = bincode::deserialize(&encoded_signature).unwrap();
 
         assert_eq!(signature, decoded_signature);
     }
 
     #[test]
-    fn serialize_deserialize_public_key() {
+    fn serialize_deserialize_public_key_bincode() {
         let public_key: PublicKey = PublicKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
-        let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
-        let decoded_public_key: PublicKey = deserialize(&encoded_public_key).unwrap();
+        let encoded_public_key: Vec<u8> = bincode::serialize(&public_key).unwrap();
+        let decoded_public_key: PublicKey = bincode::deserialize(&encoded_public_key).unwrap();
 
         assert_eq!(&PUBLIC_KEY_BYTES[..], &encoded_public_key[encoded_public_key.len() - 32..]);
         assert_eq!(public_key, decoded_public_key);
     }
 
     #[test]
-    fn serialize_deserialize_secret_key() {
+    fn serialize_deserialize_secret_key_bincode() {
         let secret_key: SecretKey = SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap();
-        let encoded_secret_key: Vec<u8> = serialize(&secret_key, Infinite).unwrap();
-        let decoded_secret_key: SecretKey = deserialize(&encoded_secret_key).unwrap();
+        let encoded_secret_key: Vec<u8> = bincode::serialize(&secret_key).unwrap();
+        let decoded_secret_key: SecretKey = bincode::deserialize(&encoded_secret_key).unwrap();
 
         for i in 0..32 {
             assert_eq!(SECRET_KEY_BYTES[i], decoded_secret_key.as_bytes()[i]);
@@ -301,8 +298,8 @@ mod serialisation {
     #[test]
     fn serialize_deserialize_keypair_bincode() {
         let keypair = Keypair::from_bytes(&KEYPAIR_BYTES).unwrap();
-        let encoded_keypair: Vec<u8> = serialize(&keypair, Infinite).unwrap();
-        let decoded_keypair: Keypair = deserialize(&encoded_keypair).unwrap();
+        let encoded_keypair: Vec<u8> = bincode::serialize(&keypair).unwrap();
+        let decoded_keypair: Keypair = bincode::deserialize(&encoded_keypair).unwrap();
 
         for i in 0..64 {
             assert_eq!(KEYPAIR_BYTES[i], decoded_keypair.to_bytes()[i]);
@@ -323,18 +320,18 @@ mod serialisation {
     #[test]
     fn serialize_public_key_size() {
         let public_key: PublicKey = PublicKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
-        assert_eq!(serialized_size(&public_key) as usize, 40); // These sizes are specific to bincode==1.0.1
+        assert_eq!(bincode::serialized_size(&public_key).unwrap() as usize, PUBLIC_KEY_LENGTH);
     }
 
     #[test]
     fn serialize_signature_size() {
         let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
-        assert_eq!(serialized_size(&signature) as usize, 64); // These sizes are specific to bincode==1.0.1
+        assert_eq!(bincode::serialized_size(&signature).unwrap() as usize, SIGNATURE_LENGTH);
     }
 
     #[test]
     fn serialize_secret_key_size() {
         let secret_key: SecretKey = SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap();
-        assert_eq!(serialized_size(&secret_key) as usize, 40); // These sizes are specific to bincode==1.0.1
+        assert_eq!(bincode::serialized_size(&secret_key).unwrap() as usize, SECRET_KEY_LENGTH);
     }
 }

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -275,12 +275,30 @@ mod serialisation {
     }
 
     #[test]
+    fn serialize_deserialize_signature_json() {
+        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+        let encoded_signature = serde_json::to_string(&signature).unwrap();
+        let decoded_signature: Signature = serde_json::from_str(&encoded_signature).unwrap();
+
+        assert_eq!(signature, decoded_signature);
+    }
+
+    #[test]
     fn serialize_deserialize_public_key_bincode() {
         let public_key: PublicKey = PublicKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
         let encoded_public_key: Vec<u8> = bincode::serialize(&public_key).unwrap();
         let decoded_public_key: PublicKey = bincode::deserialize(&encoded_public_key).unwrap();
 
-        assert_eq!(&PUBLIC_KEY_BYTES[..], &encoded_public_key[encoded_public_key.len() - 32..]);
+        assert_eq!(&PUBLIC_KEY_BYTES[..], &encoded_public_key[..]);
+        assert_eq!(public_key, decoded_public_key);
+    }
+
+    #[test]
+    fn serialize_deserialize_public_key_json() {
+        let public_key: PublicKey = PublicKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
+        let encoded_public_key = serde_json::to_string(&public_key).unwrap();
+        let decoded_public_key: PublicKey = serde_json::from_str(&encoded_public_key).unwrap();
+
         assert_eq!(public_key, decoded_public_key);
     }
 
@@ -296,10 +314,32 @@ mod serialisation {
     }
 
     #[test]
+    fn serialize_deserialize_secret_key_json() {
+        let secret_key: SecretKey = SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap();
+        let encoded_secret_key = serde_json::to_string(&secret_key).unwrap();
+        let decoded_secret_key: SecretKey = serde_json::from_str(&encoded_secret_key).unwrap();
+
+        for i in 0..32 {
+            assert_eq!(SECRET_KEY_BYTES[i], decoded_secret_key.as_bytes()[i]);
+        }
+    }
+
+    #[test]
     fn serialize_deserialize_keypair_bincode() {
         let keypair = Keypair::from_bytes(&KEYPAIR_BYTES).unwrap();
         let encoded_keypair: Vec<u8> = bincode::serialize(&keypair).unwrap();
         let decoded_keypair: Keypair = bincode::deserialize(&encoded_keypair).unwrap();
+
+        for i in 0..64 {
+            assert_eq!(KEYPAIR_BYTES[i], decoded_keypair.to_bytes()[i]);
+        }
+    }
+
+    #[test]
+    fn serialize_deserialize_keypair_json() {
+        let keypair = Keypair::from_bytes(&KEYPAIR_BYTES).unwrap();
+        let encoded_keypair = serde_json::to_string(&keypair).unwrap();
+        let decoded_keypair: Keypair = serde_json::from_str(&encoded_keypair).unwrap();
 
         for i in 0..64 {
             assert_eq!(KEYPAIR_BYTES[i], decoded_keypair.to_bytes()[i]);


### PR DESCRIPTION
In serde, the fixed length byte array (i.e. `[u8; LENGTH]`) and normal byte array (i.e., `&[u8]`) are two different data types. In the previous implementation, these two data types are mixed together. As such, the deserialization operation will fail for certain encoding like json.

This PR fixes this issue by using the fixed length byte array as the serde internal data types for all data structures. This also comes with the benefit to reduce the size of the encoded data.

We also add more tests to prevent future breakage.

Noted that this PR introduced breaking changes. However, the previous serde implementation was already partially broken. 