### PR TITLE
bump version of curve25519-dalek and sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false }
+curve25519-dalek = { version = "3", default-features = false }
 ed25519 = { version = "1", default-features = false }
 merlin = { version = "2", default-features = false, optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -172,7 +172,7 @@ impl Keypair {
     /// // Create a hash digest object which we'll feed the message into:
     /// let mut prehashed: Sha512 = Sha512::new();
     ///
-    /// prehashed.input(message);
+    /// prehashed.update(message);
     /// # }
     /// #
     /// # #[cfg(not(feature = "std"))]
@@ -216,7 +216,7 @@ impl Keypair {
     /// # let keypair: Keypair = Keypair::generate(&mut csprng);
     /// # let message: &[u8] = b"All I want is to pet all of the dogs.";
     /// # let mut prehashed: Sha512 = Sha512::new();
-    /// # prehashed.input(message);
+    /// # prehashed.update(message);
     /// #
     /// let context: &[u8] = b"Ed25519DalekSignPrehashedDoctest";
     ///
@@ -294,7 +294,7 @@ impl Keypair {
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
     /// let mut prehashed: Sha512 = Sha512::new();
-    /// prehashed.input(message);
+    /// prehashed.update(message);
     ///
     /// let context: &[u8] = b"Ed25519DalekSignPrehashedDoctest";
     ///
@@ -302,7 +302,7 @@ impl Keypair {
     ///
     /// // The sha2::Sha512 struct doesn't implement Copy, so we'll have to create a new one:
     /// let mut prehashed_again: Sha512 = Sha512::default();
-    /// prehashed_again.input(message);
+    /// prehashed_again.update(message);
     ///
     /// let verified = keypair.public.verify_prehashed(prehashed_again, Some(context), &sig);
     ///

--- a/src/public.rs
+++ b/src/public.rs
@@ -60,8 +60,8 @@ impl<'a> From<&'a SecretKey> for PublicKey {
         let mut hash: [u8; 64] = [0u8; 64];
         let mut digest: [u8; 32] = [0u8; 32];
 
-        h.input(secret_key.as_bytes());
-        hash.copy_from_slice(h.result().as_slice());
+        h.update(secret_key.as_bytes());
+        hash.copy_from_slice(h.finalize().as_slice());
 
         digest.copy_from_slice(&hash[..32]);
 
@@ -201,13 +201,13 @@ impl PublicKey {
 
         let minus_A: EdwardsPoint = -self.1;
 
-        h.input(b"SigEd25519 no Ed25519 collisions");
-        h.input(&[1]); // Ed25519ph
-        h.input(&[ctx.len() as u8]);
-        h.input(ctx);
-        h.input(signature.R.as_bytes());
-        h.input(self.as_bytes());
-        h.input(prehashed_message.result().as_slice());
+        h.update(b"SigEd25519 no Ed25519 collisions");
+        h.update(&[1]); // Ed25519ph
+        h.update(&[ctx.len() as u8]);
+        h.update(ctx);
+        h.update(signature.R.as_bytes());
+        h.update(self.as_bytes());
+        h.update(prehashed_message.finalize().as_slice());
 
         k = Scalar::from_hash(h);
         R = EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &signature.s);
@@ -306,9 +306,9 @@ impl PublicKey {
             return Err(InternalError::VerifyError.into());
         }
 
-        h.input(signature.R.as_bytes());
-        h.input(self.as_bytes());
-        h.input(&message);
+        h.update(signature.R.as_bytes());
+        h.update(self.as_bytes());
+        h.update(&message);
 
         k = Scalar::from_hash(h);
         R = EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &signature.s);
@@ -341,9 +341,9 @@ impl Verifier<ed25519::Signature> for PublicKey {
         let k: Scalar;
         let minus_A: EdwardsPoint = -self.1;
 
-        h.input(signature.R.as_bytes());
-        h.input(self.as_bytes());
-        h.input(&message);
+        h.update(signature.R.as_bytes());
+        h.update(self.as_bytes());
+        h.update(&message);
 
         k = Scalar::from_hash(h);
         R = EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &signature.s);

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -283,8 +283,8 @@ impl<'a> From<&'a SecretKey> for ExpandedSecretKey {
         let mut lower: [u8; 32] = [0u8; 32];
         let mut upper: [u8; 32] = [0u8; 32];
 
-        h.input(secret_key.as_bytes());
-        hash.copy_from_slice(h.result().as_slice());
+        h.update(secret_key.as_bytes());
+        hash.copy_from_slice(h.finalize().as_slice());
 
         lower.copy_from_slice(&hash[00..32]);
         upper.copy_from_slice(&hash[32..64]);
@@ -409,16 +409,16 @@ impl ExpandedSecretKey {
         let s: Scalar;
         let k: Scalar;
 
-        h.input(&self.nonce);
-        h.input(&message);
+        h.update(&self.nonce);
+        h.update(&message);
 
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
         h = Sha512::new();
-        h.input(R.as_bytes());
-        h.input(public_key.as_bytes());
-        h.input(&message);
+        h.update(R.as_bytes());
+        h.update(public_key.as_bytes());
+        h.update(&message);
 
         k = Scalar::from_hash(h);
         s = &(&k * &self.key) + &r;
@@ -472,7 +472,7 @@ impl ExpandedSecretKey {
         let ctx_len: u8 = ctx.len() as u8;
 
         // Get the result of the pre-hashed message.
-        prehash.copy_from_slice(prehashed_message.result().as_slice());
+        prehash.copy_from_slice(prehashed_message.finalize().as_slice());
 
         // This is the dumbest, ten-years-late, non-admission of fucking up the
         // domain separation I have ever seen.  Why am I still required to put

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -101,8 +101,8 @@ mod vectors {
         let mut prehash_for_signing: Sha512 = Sha512::default();
         let mut prehash_for_verifying: Sha512 = Sha512::default();
 
-        prehash_for_signing.input(&msg_bytes[..]);
-        prehash_for_verifying.input(&msg_bytes[..]);
+        prehash_for_signing.update(&msg_bytes[..]);
+        prehash_for_verifying.update(&msg_bytes[..]);
 
         let sig2: Signature = keypair.sign_prehashed(prehash_for_signing, None).unwrap();
 
@@ -155,16 +155,16 @@ mod integrations {
 
         // ugh… there's no `impl Copy for Sha512`… i hope we can all agree these are the same hashes
         let mut prehashed_good1: Sha512 = Sha512::default();
-        prehashed_good1.input(good);
+        prehashed_good1.update(good);
         let mut prehashed_good2: Sha512 = Sha512::default();
-        prehashed_good2.input(good);
+        prehashed_good2.update(good);
         let mut prehashed_good3: Sha512 = Sha512::default();
-        prehashed_good3.input(good);
+        prehashed_good3.update(good);
 
         let mut prehashed_bad1: Sha512 = Sha512::default();
-        prehashed_bad1.input(bad);
+        prehashed_bad1.update(bad);
         let mut prehashed_bad2: Sha512 = Sha512::default();
-        prehashed_bad2.input(bad);
+        prehashed_bad2.update(bad);
 
         let context: &[u8] = b"testing testing 1 2 3";
 


### PR DESCRIPTION
Heya

We're moving our project to use the newer `sha2` and `curve25519-dalek` libraries, but since we also depend on `ed25519-dalek` we need those libraries updated here as well.
I haven't updated the version in `Cargo.toml` since I'm not sure how you'd like to go about that, assuming you are willing to accept this patch.

Thank you!