### PR TITLE
Workaround for rand crate "nightly" feature breakage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ harness = false
 default = ["std", "u64_backend"]
 std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
-nightly = ["curve25519-dalek/nightly", "rand/nightly"]
+nightly = ["curve25519-dalek/nightly"]
 serde = ["serde_crate", "ed25519/serde"]
 batch = ["merlin", "rand"]
 # This feature enables deterministic batch verification.


### PR DESCRIPTION
Cf. https://github.com/rust-random/rand/issues/1047 and https://travis-ci.org/github/dalek-cryptography/ed25519-dalek/builds/729155886