### PR TITLE
Fix serde implementation for serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ merlin = { version = "2", default-features = false, optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
+serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
@@ -52,7 +53,7 @@ default = ["std", "rand", "u64_backend"]
 std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek/nightly"]
-serde = ["serde_crate", "ed25519/serde"]
+serde = ["serde_crate", "serde_bytes", "ed25519/serde"]
 batch = ["merlin", "rand"]
 # This feature enables deterministic batch verification.
 batch_deterministic = ["merlin", "rand", "rand_core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 
 [dev-dependencies]
 hex = "^0.4"
-bincode = "^0.9"
+bincode = "1.0"
+serde_json = "1.0"
 criterion = "0.3"
 rand = "0.7"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@
 //! # fn main() {
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
-//! use bincode::{serialize, Infinite};
+//! use bincode::serialize;
 //! # let mut csprng = OsRng{};
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -184,8 +184,8 @@
 //! # let public_key: PublicKey = keypair.public;
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //!
-//! let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
-//! let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
+//! let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
+//! let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
 //! # }
 //! # #[cfg(not(feature = "serde"))]
 //! # fn main() {}
@@ -206,7 +206,7 @@
 //! # fn main() {
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
-//! # use bincode::{serialize, Infinite};
+//! # use bincode::serialize;
 //! use bincode::deserialize;
 //!
 //! # let mut csprng = OsRng{};
@@ -215,8 +215,8 @@
 //! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
-//! # let encoded_public_key: Vec<u8> = serialize(&public_key, Infinite).unwrap();
-//! # let encoded_signature: Vec<u8> = serialize(&signature, Infinite).unwrap();
+//! # let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
+//! # let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
 //! let decoded_public_key: PublicKey = deserialize(&encoded_public_key).unwrap();
 //! let decoded_signature: Signature = deserialize(&encoded_signature).unwrap();
 //!

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -25,11 +25,9 @@ use sha2::Sha512;
 #[cfg(feature = "serde")]
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serde")]
-use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "serde")]
-use serde::{Deserializer, Serializer};
+use serde_bytes::{Bytes as SerdeBytes, ByteBuf as SerdeByteBuf};
 
 use zeroize::Zeroize;
 
@@ -184,7 +182,7 @@ impl Serialize for SecretKey {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(self.as_bytes())
+        SerdeBytes::new(self.as_bytes()).serialize(serializer)
     }
 }
 
@@ -194,23 +192,8 @@ impl<'d> Deserialize<'d> for SecretKey {
     where
         D: Deserializer<'d>,
     {
-        struct SecretKeyVisitor;
-
-        impl<'d> Visitor<'d> for SecretKeyVisitor {
-            type Value = SecretKey;
-
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                formatter.write_str("An ed25519 secret key as 32 bytes, as specified in RFC8032.")
-            }
-
-            fn visit_bytes<E>(self, bytes: &[u8]) -> Result<SecretKey, E>
-            where
-                E: SerdeError,
-            {
-                SecretKey::from_bytes(bytes).or(Err(SerdeError::invalid_length(bytes.len(), &self)))
-            }
-        }
-        deserializer.deserialize_bytes(SecretKeyVisitor)
+        let bytes = <SerdeByteBuf>::deserialize(deserializer)?;
+        SecretKey::from_bytes(bytes.as_ref()).map_err(SerdeError::custom)
     }
 }
 
@@ -521,7 +504,8 @@ impl Serialize for ExpandedSecretKey {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.to_bytes()[..])
+        let bytes = &self.to_bytes()[..];
+        SerdeBytes::new(bytes).serialize(serializer)
     }
 }
 
@@ -531,26 +515,8 @@ impl<'d> Deserialize<'d> for ExpandedSecretKey {
     where
         D: Deserializer<'d>,
     {
-        struct ExpandedSecretKeyVisitor;
-
-        impl<'d> Visitor<'d> for ExpandedSecretKeyVisitor {
-            type Value = ExpandedSecretKey;
-
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                formatter.write_str(
-                    "An ed25519 expanded secret key as 64 bytes, as specified in RFC8032.",
-                )
-            }
-
-            fn visit_bytes<E>(self, bytes: &[u8]) -> Result<ExpandedSecretKey, E>
-            where
-                E: SerdeError,
-            {
-                ExpandedSecretKey::from_bytes(bytes)
-                    .or(Err(SerdeError::invalid_length(bytes.len(), &self)))
-            }
-        }
-        deserializer.deserialize_bytes(ExpandedSecretKeyVisitor)
+        let bytes = <SerdeByteBuf>::deserialize(deserializer)?;
+        ExpandedSecretKey::from_bytes(bytes.as_ref()).map_err(SerdeError::custom)
     }
 }
 


### PR DESCRIPTION
Based on discussion in #140.

We use the [serde_bytes](https://github.com/serde-rs/bytes) crate for serialization implementations, which simplifies codes and fixes issues for serde_json.