### PR TITLE
batch verification malleability issue when used with fully deterministic nonce generation

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -58,12 +58,17 @@ impl BatchTranscript for Transcript {
     /// Each is also prefixed with their index in the vector.
     fn append_scalars(&mut self, scalars: &Vec<Scalar>) {
         for (i, scalar) in scalars.iter().enumerate() {
-            // XXX add message length into transcript
             self.append_u64(b"", i as u64);
             self.append_message(b"hram", scalar.as_bytes());
         }
     }
 
+    /// Append the lengths of the messages into the transcript.
+    ///
+    /// This is done out of an (potential over-)abundance of caution, to guard
+    /// against the unlikely event of collisions.  However, a nicer way to do
+    /// this would be to append the message length before the message, but this
+    /// is messy w.r.t. the calculations of the `H(R||A||M)`s above.
     fn append_message_lengths(&mut self, message_lengths: &Vec<usize>) {
         for (i, len) in message_lengths.iter().enumerate() {
             self.append_u64(b"", i as u64);


### PR DESCRIPTION
Issue found by @real_or_random and @jonasnick.

Only if compiled with `--features "batch_deterministic"`, when `verify_batch()` was called, an adversary not in control of the secret key(s) could use a signature malleability bug to take any signature, `(s_i, R_i)`, and produce a signature `(s'_i, R_i)` where e.g. `s'_i = -z_i` which would erroneously pass batch verification when purely deterministic nonce generation was used, due to the sigma protocol transcript used to seed the CSPRNG not including the `s` components of the signatures in the context. The fix is simply to add the `s` components to the transcript.