### PR TITLE
Remove cautionary usage warning from `PublicKey::from_bytes`

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -91,12 +91,6 @@ impl PublicKey {
 
     /// Construct a `PublicKey` from a slice of bytes.
     ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this
-    /// method actually represent a `curve25519_dalek::curve::CompressedEdwardsY`
-    /// and that said compressed point is actually a point on the curve.
-    ///
     /// # Example
     ///
     /// ```
@@ -123,7 +117,7 @@ impl PublicKey {
     ///
     /// # Returns
     ///
-    /// A `Result` whose okay value is an EdDSA `PublicKey` or whose error value
+    /// A `Result` whose okay value is a valid EdDSA `PublicKey` or whose error value
     /// is an `SignatureError` describing the error that occurred.
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<PublicKey, SignatureError> {


### PR DESCRIPTION
This warning implies that users of `PublicKey::from_bytes` must do
separate validation before calling it. This used to be the case, but the
eager decompression added in
https://github.com/dalek-cryptography/ed25519-dalek/commit/8dbaf9a8d249a24a5225a1247195d4135669f608
means that `PublicKey::from_bytes(bytes).is_ok()` implies that `bytes`
represents a valid `CompressedEdwardsY`.