### PR TITLE
Add an optimization for trivial batch sizes.

### DIFF
--- a/benches/ed25519_benchmarks.rs
+++ b/benches/ed25519_benchmarks.rs
@@ -69,7 +69,7 @@ mod ed25519_benches {
     }
 
     fn verify_batch_signatures(c: &mut Criterion) {
-        static BATCH_SIZES: [usize; 8] = [4, 8, 16, 32, 64, 96, 128, 256];
+        static BATCH_SIZES: [usize; 11] = [0, 1, 2, 4, 8, 16, 32, 64, 96, 128, 256];
 
         c.bench_function_over_inputs(
             "Ed25519 batch signature verification",

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -235,6 +235,15 @@ pub fn verify_batch(
         }.into());
     }
 
+    // If we have been given a trivial batch size, we can exit early
+    // without going through the trouble of batch verification.
+    if signatures.len() == 0 {
+        return Ok(());
+    } else if signatures.len() == 1 {
+        use crate::ed25519::signature::Verifier;
+        return public_keys[0].verify(messages[0], &signatures[0]);
+    }
+
     // Convert all signatures to `InternalSignature`
     let signatures = signatures
         .iter()


### PR DESCRIPTION
[Hello, fine Dalek maintainers! This is my first open-source rust patch.]

When told to validate zero signatures, there's no need to go through
any pre-computation to be sure that there are no invalid signatures
in the empty set.

When told to validate one signature, a single signature verification
call is faster than validating a single signature via the
batch-verification mechanism.

On my not-very-reliable desktop, the performance difference is ~99%
when there are no signatures, and ~25% when there is one signature.

Why would a programmer use batch verification in this case?
Sometimes it makes sense to write code that handles an unknown
number of signatures at once: for example, when validating a
download that contains multiple objects, between zero and many of
which are ed25519-signed objects.  Instead of the programmer having
to pick which API to use, IMO it's better just to make the "batch"
API fast in all cases.

This commit adds cases for 0 and 1-signature batches to the
benchmark.  It also adds a case for a 2-signature batch, to verify
that batch verification is faster for all n>1.