### PR TITLE
Speed up compilation by avoiding syn via zeroize_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand_core = { version = "0.5", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 hex = "^0.4"

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -40,9 +40,13 @@ use crate::signature::*;
 ///
 /// Instances of this secret are automatically overwritten with zeroes when they
 /// fall out of scope.
-#[derive(Zeroize)]
-#[zeroize(drop)] // Overwrite secret key material with null bytes when it goes out of scope.
 pub struct SecretKey(pub(crate) [u8; SECRET_KEY_LENGTH]);
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.0.zeroize()
+    }
+}
 
 impl Debug for SecretKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -235,11 +239,16 @@ impl<'d> Deserialize<'d> for SecretKey {
 // same signature scheme, and which both fail in exactly the same way.  For a
 // better-designed, Schnorr-based signature scheme, see Trevor Perrin's work on
 // "generalised EdDSA" and "VXEdDSA".
-#[derive(Zeroize)]
-#[zeroize(drop)] // Overwrite secret key material with null bytes when it goes out of scope.
 pub struct ExpandedSecretKey {
     pub(crate) key: Scalar,
     pub(crate) nonce: [u8; 32],
+}
+
+impl Drop for ExpandedSecretKey {
+    fn drop(&mut self) {
+        self.key.zeroize();
+        self.nonce.zeroize()
+    }
 }
 
 impl<'a> From<&'a SecretKey> for ExpandedSecretKey {


### PR DESCRIPTION
Avoiding `syn` cuts release and debug compilation on my machine from ~6.5s to ~4.5s, saving the ~4000 daily users of this crate at least 2 hours each day assuming the average CPU is less speedy than the 9900k I tested this with.