### PR TITLE
Update to rand 0.8 and rand-core 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ features = ["nightly", "batch"]
 curve25519-dalek = { version = "3", default-features = false }
 ed25519 = { version = "1", default-features = false }
 merlin = { version = "2", default-features = false, optional = true }
-rand = { version = "0.7", default-features = false, optional = true }
-rand_core = { version = "0.5", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
@@ -37,7 +37,7 @@ hex = "^0.4"
 bincode = "1.0"
 serde_json = "1.0"
 criterion = "0.3"
-rand = "0.7"
+rand = "0.8"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
 


### PR DESCRIPTION
Bumps rand and rand-core to the latest version.

Note that because rand is a public dependency (it is exposed in Keypair::generate), this is a breaking change and should be released only with a major version bump.