### PR TITLE
Re-export rand crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ extern crate curve25519_dalek;
 #[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
 extern crate merlin;
 #[cfg(any(feature = "batch", feature = "std", feature = "alloc", test))]
-extern crate rand;
+pub extern crate rand;
 #[cfg(feature = "serde")]
 extern crate serde_crate as serde;
 extern crate sha2;


### PR DESCRIPTION
The APIs in `ed25519_dalek` depend on the `rand` crate.
This can cause conflicts when an application needs to
provide different versions of `rand` to satisfy their
interfaces. By re-exporting the `rand` crate this issue
is eliminated.