### PR TITLE
Remove rand from public api.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ features = ["nightly", "batch"]
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false }
 ed25519 = { version = "1", default-features = false }
-merlin = { version = "2", default-features = false, optional = true }
-rand = { version = "0.7", default-features = false, optional = true }
-rand_core = { version = "0.5", default-features = false, optional = true }
+merlin = { version = "3.0.0", default-features = false, optional = true }
+rand = { version = "0.8.3", default-features = false, optional = true }
+rand_core = { version = "0.6.2", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
@@ -34,12 +34,12 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 
 [dev-dependencies]
 hex = "^0.4"
-bincode = "1.0"
+bincode = "1.3.3"
 serde_json = "1.0"
 criterion = "0.3"
-rand = "0.7"
+rand = "0.8.3"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }
-toml = { version = "0.5" }
+toml = "0.5.8"
 
 [[bench]]
 name = "ed25519_benchmarks"

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -10,7 +10,7 @@
 //! ed25519 keypairs.
 
 #[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 
 #[cfg(feature = "serde")]
 use serde::de::Error as SerdeError;
@@ -95,6 +95,28 @@ impl Keypair {
     /// # Example
     ///
     /// ```
+    /// extern crate ed25519_dalek;
+    ///
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// #
+    /// use ed25519_dalek::Keypair;
+    /// let keypair = Keypair::generate();
+    /// # }
+    /// #
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() { }
+    /// ```
+    #[cfg(feature = "rand")]
+    pub fn generate() -> Keypair {
+        Self::generate_with_rng(&mut OsRng {})
+    }
+
+    /// Generate an ed25519 keypair.
+    ///
+    /// # Example
+    ///
+    /// ```
     /// extern crate rand;
     /// extern crate ed25519_dalek;
     ///
@@ -106,7 +128,7 @@ impl Keypair {
     /// use ed25519_dalek::Signature;
     ///
     /// let mut csprng = OsRng{};
-    /// let keypair: Keypair = Keypair::generate(&mut csprng);
+    /// let keypair: Keypair = Keypair::generate_with_rng(&mut csprng);
     ///
     /// # }
     /// #
@@ -124,11 +146,11 @@ impl Keypair {
     /// which is available with `use sha2::Sha512` as in the example above.
     /// Other suitable hash functions include Keccak-512 and Blake2b-512.
     #[cfg(feature = "rand")]
-    pub fn generate<R>(csprng: &mut R) -> Keypair
+    pub fn generate_with_rng<R>(csprng: &mut R) -> Keypair
     where
         R: CryptoRng + RngCore,
     {
-        let sk: SecretKey = SecretKey::generate(csprng);
+        let sk: SecretKey = SecretKey::generate_with_rng(csprng);
         let pk: PublicKey = (&sk).into();
 
         Keypair{ public: pk, secret: sk }
@@ -154,18 +176,15 @@ impl Keypair {
     ///
     /// ```
     /// extern crate ed25519_dalek;
-    /// extern crate rand;
     ///
     /// use ed25519_dalek::Digest;
     /// use ed25519_dalek::Keypair;
     /// use ed25519_dalek::Sha512;
     /// use ed25519_dalek::Signature;
-    /// use rand::rngs::OsRng;
     ///
     /// # #[cfg(feature = "std")]
     /// # fn main() {
-    /// let mut csprng = OsRng{};
-    /// let keypair: Keypair = Keypair::generate(&mut csprng);
+    /// let keypair: Keypair = Keypair::generate();
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
     /// // Create a hash digest object which we'll feed the message into:
@@ -201,18 +220,15 @@ impl Keypair {
     ///
     /// ```
     /// # extern crate ed25519_dalek;
-    /// # extern crate rand;
     /// #
     /// # use ed25519_dalek::Digest;
     /// # use ed25519_dalek::Keypair;
     /// # use ed25519_dalek::Signature;
     /// # use ed25519_dalek::SignatureError;
     /// # use ed25519_dalek::Sha512;
-    /// # use rand::rngs::OsRng;
     /// #
     /// # fn do_test() -> Result<Signature, SignatureError> {
-    /// # let mut csprng = OsRng{};
-    /// # let keypair: Keypair = Keypair::generate(&mut csprng);
+    /// # let keypair: Keypair = Keypair::generate();
     /// # let message: &[u8] = b"All I want is to pet all of the dogs.";
     /// # let mut prehashed: Sha512 = Sha512::new();
     /// # prehashed.update(message);
@@ -278,18 +294,15 @@ impl Keypair {
     ///
     /// ```
     /// extern crate ed25519_dalek;
-    /// extern crate rand;
     ///
     /// use ed25519_dalek::Digest;
     /// use ed25519_dalek::Keypair;
     /// use ed25519_dalek::Signature;
     /// use ed25519_dalek::SignatureError;
     /// use ed25519_dalek::Sha512;
-    /// use rand::rngs::OsRng;
     ///
     /// # fn do_test() -> Result<(), SignatureError> {
-    /// let mut csprng = OsRng{};
-    /// let keypair: Keypair = Keypair::generate(&mut csprng);
+    /// let keypair: Keypair = Keypair::generate();
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
     /// let mut prehashed: Sha512 = Sha512::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,14 @@
 //! the operating system's builtin PRNG:
 //!
 //! ```
-//! extern crate rand;
 //! extern crate ed25519_dalek;
 //!
 //! # #[cfg(feature = "std")]
 //! # fn main() {
-//! use rand::rngs::OsRng;
 //! use ed25519_dalek::Keypair;
 //! use ed25519_dalek::Signature;
 //!
-//! let mut csprng = OsRng{};
-//! let keypair: Keypair = Keypair::generate(&mut csprng);
+//! let keypair: Keypair = Keypair::generate();
 //! # }
 //! #
 //! # #[cfg(not(feature = "std"))]
@@ -39,13 +36,10 @@
 //! We can now use this `keypair` to sign a message:
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::Keypair;
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! use ed25519_dalek::{Signature, Signer};
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! let signature: Signature = keypair.sign(message);
@@ -56,13 +50,10 @@
 //! that `message`:
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer};
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //! use ed25519_dalek::Verifier;
@@ -74,16 +65,13 @@
 //! verify this signature:
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::Keypair;
 //! # use ed25519_dalek::Signature;
 //! # use ed25519_dalek::Signer;
 //! use ed25519_dalek::{PublicKey, Verifier};
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //!
@@ -101,14 +89,11 @@
 //! verify your signatures!)
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, PublicKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
@@ -123,15 +108,12 @@
 //! And similarly, decoded from bytes with `::from_bytes()`:
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # use std::convert::TryFrom;
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, PublicKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), SignatureError> {
-//! # let mut csprng = OsRng{};
-//! # let keypair_orig: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair_orig: Keypair = Keypair::generate();
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature_orig: Signature = keypair_orig.sign(message);
 //! # let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = keypair_orig.public.to_bytes();
@@ -165,7 +147,6 @@
 //! For example, using [bincode](https://github.com/TyOverby/bincode):
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
 //! # extern crate serde_crate as serde;
@@ -174,11 +155,9 @@
 //!
 //! # #[cfg(feature = "serde")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
 //! use bincode::serialize;
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;
@@ -195,7 +174,6 @@
 //! recipient may deserialise them and verify:
 //!
 //! ```
-//! # extern crate rand;
 //! # extern crate ed25519_dalek;
 //! # #[cfg(feature = "serde")]
 //! # extern crate serde_crate as serde;
@@ -204,13 +182,11 @@
 //! #
 //! # #[cfg(feature = "serde")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, Verifier, PublicKey};
 //! # use bincode::serialize;
 //! use bincode::deserialize;
 //!
-//! # let mut csprng = OsRng{};
-//! # let keypair: Keypair = Keypair::generate(&mut csprng);
+//! # let keypair: Keypair = Keypair::generate();
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //! # let public_key: PublicKey = keypair.public;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -18,7 +18,7 @@ use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
 
 #[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 
 use sha2::Sha512;
 
@@ -116,24 +116,46 @@ impl SecretKey {
         Ok(SecretKey(bits))
     }
 
-    /// Generate a `SecretKey` from a `csprng`.
+    /// Generate `SecretKey`.
     ///
     /// # Example
     ///
     /// ```
-    /// extern crate rand;
     /// extern crate ed25519_dalek;
     ///
     /// # #[cfg(feature = "std")]
     /// # fn main() {
     /// #
-    /// use rand::rngs::OsRng;
+    /// use ed25519_dalek::SecretKey;
+    /// let secret_key = SecretKey::generate();
+    /// # }
+    /// #
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() { }
+    /// ```
+    #[cfg(feature = "rand")]
+    pub fn generate() -> SecretKey {
+        Self::generate_with_rng(&mut OsRng {})
+    }
+
+    /// Generate a `SecretKey` from a `csprng`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate ed25519_dalek;
+    /// extern crate rand;
+    ///
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// #
     /// use ed25519_dalek::PublicKey;
     /// use ed25519_dalek::SecretKey;
     /// use ed25519_dalek::Signature;
+    /// use rand::rngs::OsRng;
     ///
     /// let mut csprng = OsRng{};
-    /// let secret_key: SecretKey = SecretKey::generate(&mut csprng);
+    /// let secret_key: SecretKey = SecretKey::generate_with_rng(&mut csprng);
     /// # }
     /// #
     /// # #[cfg(not(feature = "std"))]
@@ -143,18 +165,15 @@ impl SecretKey {
     /// Afterwards, you can generate the corresponding public:
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate ed25519_dalek;
     /// #
     /// # fn main() {
     /// #
-    /// # use rand::rngs::OsRng;
     /// # use ed25519_dalek::PublicKey;
     /// # use ed25519_dalek::SecretKey;
     /// # use ed25519_dalek::Signature;
     /// #
-    /// # let mut csprng = OsRng{};
-    /// # let secret_key: SecretKey = SecretKey::generate(&mut csprng);
+    /// # let secret_key: SecretKey = SecretKey::generate();
     ///
     /// let public_key: PublicKey = (&secret_key).into();
     /// # }
@@ -164,7 +183,7 @@ impl SecretKey {
     ///
     /// A CSPRNG with a `fill_bytes()` method, e.g. `rand::OsRng`
     #[cfg(feature = "rand")]
-    pub fn generate<T>(csprng: &mut T) -> SecretKey
+    pub fn generate_with_rng<T>(csprng: &mut T) -> SecretKey
     where
         T: CryptoRng + RngCore,
     {
@@ -248,17 +267,14 @@ impl<'a> From<&'a SecretKey> for ExpandedSecretKey {
     /// # Examples
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;
     /// #
     /// # fn main() {
     /// #
-    /// use rand::rngs::OsRng;
     /// use ed25519_dalek::{SecretKey, ExpandedSecretKey};
     ///
-    /// let mut csprng = OsRng{};
-    /// let secret_key: SecretKey = SecretKey::generate(&mut csprng);
+    /// let secret_key: SecretKey = SecretKey::generate();
     /// let expanded_secret_key: ExpandedSecretKey = ExpandedSecretKey::from(&secret_key);
     /// # }
     /// ```
@@ -294,18 +310,15 @@ impl ExpandedSecretKey {
     /// # Examples
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;
     /// #
     /// # #[cfg(feature = "std")]
     /// # fn main() {
     /// #
-    /// use rand::rngs::OsRng;
     /// use ed25519_dalek::{SecretKey, ExpandedSecretKey};
     ///
-    /// let mut csprng = OsRng{};
-    /// let secret_key: SecretKey = SecretKey::generate(&mut csprng);
+    /// let secret_key: SecretKey = SecretKey::generate();
     /// let expanded_secret_key: ExpandedSecretKey = ExpandedSecretKey::from(&secret_key);
     /// let expanded_secret_key_bytes: [u8; 64] = expanded_secret_key.to_bytes();
     ///
@@ -334,7 +347,6 @@ impl ExpandedSecretKey {
     /// # Examples
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;
     /// #
@@ -343,12 +355,10 @@ impl ExpandedSecretKey {
     /// # #[cfg(feature = "std")]
     /// # fn do_test() -> Result<ExpandedSecretKey, SignatureError> {
     /// #
-    /// use rand::rngs::OsRng;
     /// use ed25519_dalek::{SecretKey, ExpandedSecretKey};
     /// use ed25519_dalek::SignatureError;
     ///
-    /// let mut csprng = OsRng{};
-    /// let secret_key: SecretKey = SecretKey::generate(&mut csprng);
+    /// let secret_key: SecretKey = SecretKey::generate();
     /// let expanded_secret_key: ExpandedSecretKey = ExpandedSecretKey::from(&secret_key);
     /// let bytes: [u8; 64] = expanded_secret_key.to_bytes();
     /// let expanded_secret_key_again = ExpandedSecretKey::from_bytes(&bytes)?;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -117,7 +117,6 @@ mod vectors {
 #[cfg(test)]
 mod integrations {
     use super::*;
-    use rand::rngs::OsRng;
 
     #[test]
     fn sign_verify() {  // TestSignVerify
@@ -128,9 +127,7 @@ mod integrations {
         let good: &[u8] = "test message".as_bytes();
         let bad:  &[u8] = "wrong message".as_bytes();
 
-        let mut csprng = OsRng{};
-
-        keypair  = Keypair::generate(&mut csprng);
+        keypair  = Keypair::generate();
         good_sig = keypair.sign(&good);
         bad_sig  = keypair.sign(&bad);
 
@@ -151,8 +148,6 @@ mod integrations {
         let good: &[u8] = b"test message";
         let bad:  &[u8] = b"wrong message";
 
-        let mut csprng = OsRng{};
-
         // ugh… there's no `impl Copy for Sha512`… i hope we can all agree these are the same hashes
         let mut prehashed_good1: Sha512 = Sha512::default();
         prehashed_good1.update(good);
@@ -168,7 +163,7 @@ mod integrations {
 
         let context: &[u8] = b"testing testing 1 2 3";
 
-        keypair  = Keypair::generate(&mut csprng);
+        keypair  = Keypair::generate();
         good_sig = keypair.sign_prehashed(prehashed_good1, Some(context)).unwrap();
         bad_sig  = keypair.sign_prehashed(prehashed_bad1,  Some(context)).unwrap();
 
@@ -191,12 +186,11 @@ mod integrations {
             b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
             b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
             b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
-        let mut csprng = OsRng{};
         let mut keypairs: Vec<Keypair> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
         for i in 0..messages.len() {
-            let keypair: Keypair = Keypair::generate(&mut csprng);
+            let keypair: Keypair = Keypair::generate();
             signatures.push(keypair.sign(&messages[i]));
             keypairs.push(keypair);
         }
@@ -209,8 +203,7 @@ mod integrations {
 
     #[test]
     fn pubkey_from_secret_and_expanded_secret() {
-        let mut csprng = OsRng{};
-        let secret: SecretKey = SecretKey::generate(&mut csprng);
+        let secret: SecretKey = SecretKey::generate();
         let expanded_secret: ExpandedSecretKey = (&secret).into();
         let public_from_secret: PublicKey = (&secret).into(); // XXX eww
         let public_from_expanded_secret: PublicKey = (&expanded_secret).into(); // XXX eww


### PR DESCRIPTION
I expect for most users this is fine, and if some user would like to use a different `Rng` they can use the `from_bytes` call.

Since `rand` has a history of causing breakage in `ed25519-dalek` I think this change could be justified as a bug fix.

Also updates the dependencies to new versions where appropriate.

Closes #160
Closes #159
Closes #162 