### PR TITLE
WIP Updated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ features = ["nightly", "batch"]
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false }
 ed25519 = { version = "1", default-features = false }
-merlin = { version = "2", default-features = false, optional = true }
-rand = { version = "0.7", default-features = false, optional = true }
-rand_core = { version = "0.5", default-features = false, optional = true }
+merlin = { version = "3", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
-zeroize = { version = "~1.3", default-features = false }
+zeroize = { version = "1.4", default-features = false }
 
 [dev-dependencies]
-hex = "^0.4"
-bincode = "1.0"
+hex = "0.4"
+bincode = "1.3"
 serde_json = "1.0"
-criterion = "0.3"
-rand = "0.7"
+criterion = { version = "0.3", features = ["html_reports"] }
+rand = "0.8"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
 


### PR DESCRIPTION
This depends on https://github.com/dalek-cryptography/curve25519-dalek/pull/369. The tests don't currently compile because `curve25519-dalek` expects the wrong version of `rand`. Also, **this requires a major version bump** for the same reason as the aforementioned PR.

Notes on the deps I updated:
* zeroize [obeys semantic versioning](https://github.com/iqlusioninc/crates/blob/main/zeroize/CHANGELOG.md). I left it at "1.4" (rather than "1") because newness here should be prioritized over deduplication
* bincode says their format is [stable across minor revisions](https://github.com/bincode-org/bincode/blob/trunk/readme.md)
* Merlin transcripts [have not changed since v2](https://github.com/zkcrypto/merlin/blob/main/CHANGELOG.md)
* Criterion requires the `html_reports` feature in order to not display an annoying warning