### PR TITLE
Update curve25519-dalek's dependency of `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "3", default-features = false }
+curve25519-dalek = { version = "4.0.0-pre.1.", default-features = false }
 ed25519 = { version = "1", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }


### PR DESCRIPTION
This PR is not to `main`, but to `update-deps`. 

This PR updates the dependency of `curve25519-dalek` to a version that uses `rand = 0.8`.

Since the code in `update-deps` is a breaking change, I would wait for a newer release of ed25519-dalek.