### PR TITLE
RFC: New facility for exposing "bundled signatures".

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,37 +38,56 @@ pub(crate) enum InternalError {
     VerifyError,
     /// Two arrays did not match in size, making the called signature
     /// verification method impossible.
-    ArrayLengthError{ name_a: &'static str, length_a: usize,
-                      name_b: &'static str, length_b: usize,
-                      name_c: &'static str, length_c: usize, },
+    ArrayLengthError {
+        name_a: &'static str,
+        length_a: usize,
+        name_b: &'static str,
+        length_b: usize,
+        name_c: &'static str,
+        length_c: usize,
+    },
     /// An ed25519ph signature can only take up to 255 octets of context.
     PrehashedContextLengthError,
+    /// A public key did not match the key provided in a bundled signature.
+    WrongKeyError,
 }
 
 impl Display for InternalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            InternalError::PointDecompressionError
-                => write!(f, "Cannot decompress Edwards point"),
-            InternalError::ScalarFormatError
-                => write!(f, "Cannot use scalar with high-bit set"),
-            InternalError::BytesLengthError{ name: n, length: l}
-                => write!(f, "{} must be {} bytes in length", n, l),
-            InternalError::VerifyError
-                => write!(f, "Verification equation was not satisfied"),
-            InternalError::ArrayLengthError{ name_a: na, length_a: la,
-                                             name_b: nb, length_b: lb,
-                                             name_c: nc, length_c: lc, }
-                => write!(f, "Arrays must be the same length: {} has length {},
-                              {} has length {}, {} has length {}.", na, la, nb, lb, nc, lc),
-            InternalError::PrehashedContextLengthError
-                => write!(f, "An ed25519ph signature can only take up to 255 octets of context"),
+            InternalError::PointDecompressionError => write!(f, "Cannot decompress Edwards point"),
+            InternalError::ScalarFormatError => write!(f, "Cannot use scalar with high-bit set"),
+            InternalError::BytesLengthError { name: n, length: l } => {
+                write!(f, "{} must be {} bytes in length", n, l)
+            }
+            InternalError::VerifyError => write!(f, "Verification equation was not satisfied"),
+            InternalError::ArrayLengthError {
+                name_a: na,
+                length_a: la,
+                name_b: nb,
+                length_b: lb,
+                name_c: nc,
+                length_c: lc,
+            } => write!(
+                f,
+                "Arrays must be the same length: {} has length {},
+                              {} has length {}, {} has length {}.",
+                na, la, nb, lb, nc, lc
+            ),
+            InternalError::PrehashedContextLengthError => write!(
+                f,
+                "An ed25519ph signature can only take up to 255 octets of context"
+            ),
+            InternalError::WrongKeyError => write!(
+                f,
+                "Provided public key did not match key in bundled signature"
+            ),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl Error for InternalError { }
+impl Error for InternalError {}
 
 /// Errors which may occur while processing signatures and keypairs.
 ///


### PR DESCRIPTION
Sometimes it's useful to save up one or more signatures and have
them verified later on.  For example, in Arti, we sometimes want to
parse a large document containing many internal signatures, but save
the verification of the signatures for another thread.  We can't
use precomputed hashes for this, since the protocol is already
specified.  Thus, our only choice for now is to carry around the
original message--either by copy or by reference--until we're
ready to verify the signature on it.

With this patch, ed25519-dalek exposes a new type, BundledSignature.
A BundledSignature contains the public key, the InternalSignature,
and the scalar `k` needed to verify the signature against the message.
To avoid code bloat and to reuse testing, it uses these objects
internally to implement signature verification.  (According to
`cargo bench`, there is no performance loss.)

**

Please don't merge this yet. I'm marking this as a "RFC" branch for a few reasons:

First, it seems that my editor setup accidentally ran "cargo fmt" on a few of your files, and I assume you don't want that.

Second, I bet that you'll have comments on the naming and documentation, and I'd like to be responsive to those.

Third, once you think that the basic approach is reasonable, I'd like to add support for batch verification over BundledSignatures.

**

No hurry on the review here, BTW: I'm writing this for fun while I'm on vacation, and I hope you won't look at it until you also feel like it would be fun to look at some code.