### PR TITLE
Add a feature to force sha2 soft-float mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ batch = ["merlin", "rand"]
 # This feature enables deterministic batch verification.
 batch_deterministic = ["merlin", "rand", "rand_core"]
 asm = ["sha2/asm"]
+sha2-force-soft = ["sha2/force-soft"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
 u64_backend = ["curve25519-dalek/u64_backend"]


### PR DESCRIPTION
This PR adds a feature flag `sha2-force-soft` to force `sha2` crate into soft-float mode. (See [sha2/Cargo.toml](https://github.com/RustCrypto/hashes/blob/4c1d9dab614af86ba4f3f3f1e23d0444684e3e6b/sha2/Cargo.toml#L34)) This is useful for some `no_std` targets, where floating point instructions should not be generated, e.g. operating system development. Features like this cannot be enabled from outside the crate, so having this feature is necessary to use this crate with soft-float.

## Reproducing the original issue

Make a new new repo with `Cargo.toml`  contents:

```toml
[package]
name = "repro_dalek_sha2"
version = "0.1.0"
edition = "2021"

[dependencies.ed25519-dalek]
version = "*"
default-features = false
features = ["u64_backend", "alloc"]
```

Then add a `src/lib.rs`, which contains only

```rust
#![no_std]
```

And `target.json` ([a target specification](https://rust-lang.github.io/rfcs/0131-target-specification.html)):

```json
{
  "llvm-target": "x86_64-unknown-none",
  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
  "target-endian": "little",
  "target-pointer-width": "64",
  "target-c-int-width": "32",
  "arch": "x86_64",
  "os": "none",
  "linker": "ld.lld",
  "linker-flavor": "ld",
  "features": "-mmx,-sse,+soft-float",
  "disable-redzone": true,
  "panic-strategy": "abort"
}
```

And then attempt compilation with

```
cargo build --target target.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem
```

gives the following output:

```
   Compiling sha2 v0.9.9
   Compiling ed25519-dalek v1.0.1
LLVM ERROR: Do not know how to split the result of this operator!

error: could not compile `sha2`
warning: build failed, waiting for other jobs to finish...
error: build failed
```