### PR TITLE
refactor: removed a wrong left parenthesis for the  debug print

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -41,7 +41,7 @@ pub struct PublicKey(pub(crate) CompressedEdwardsY, pub(crate) EdwardsPoint);
 
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        write!(f, "PublicKey({:?}), {:?})", self.0, self.1)
+        write!(f, "PublicKey({:?}, {:?})", self.0, self.1)
     }
 }
 


### PR DESCRIPTION
Had a minor headache after the debug print showed that the `EdwardsPoint` was not inside the `PublicKey(...)`.

Signed-off-by: Berend Sliedrecht <berend@animo.id>
