### PR TITLE
Add generic methods to support non-sha512 digests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,5 @@ legacy_compatibility = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
+# This feature exposes unverified internals for compatibility with non-spec-compliant 25519 implementations
+yolo_crypto = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ harness = false
 # required-features = ["batch"]
 
 [features]
-default = ["std", "rand", "u64_backend"]
+default = ["std", "rand", "u64_backend", "basepoint_tables"]
 std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek/nightly"]
@@ -65,3 +65,5 @@ u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
 # This feature exposes unverified internals for compatibility with non-spec-compliant 25519 implementations
 yolo_crypto = []
+# Enable use of basepoint tables for accelerated operations
+basepoint_tables = ["curve25519-dalek/basepoint_tables"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,3 +277,13 @@ pub use crate::secret::*;
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
 pub use ed25519::signature::{Signer, Verifier};
 pub use ed25519::Signature;
+
+// Internal re-export [`ED25519_BASEPOINT`] using table or point depending 
+// `basepoint_tables` feature, internally this should be used in place of 
+// `_TABLE` or `_POINT`.
+
+#[cfg(feature="basepoint_tables")]
+pub(crate) use curve25519_dalek::constants::{ED25519_BASEPOINT_TABLE as ED25519_BASEPOINT};
+
+#[cfg(not(feature="basepoint_tables"))]
+pub(crate) use curve25519_dalek::constants::{ED25519_BASEPOINT_POINT as ED25519_BASEPOINT};

--- a/src/public.rs
+++ b/src/public.rs
@@ -168,7 +168,7 @@ impl PublicKey {
         bits[31] &= 127;
         bits[31] |= 64;
 
-        let point = &Scalar::from_bits(*bits) * &constants::ED25519_BASEPOINT_TABLE;
+        let point = &Scalar::from_bits(*bits) * &crate::ED25519_BASEPOINT;
         let compressed = point.compress();
 
         PublicKey(compressed, point)

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -420,7 +420,7 @@ impl ExpandedSecretKey {
         h.update(&message);
 
         r = Scalar::from_hash(h);
-        R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
+        R = (&r * &crate::ED25519_BASEPOINT).compress();
 
         h = D::new();
         h.update(R.as_bytes());
@@ -502,7 +502,7 @@ impl ExpandedSecretKey {
             .chain(&prehash[..]);
 
         r = Scalar::from_hash(h);
-        R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
+        R = (&r * &crate::ED25519_BASEPOINT).compress();
 
         h = Sha512::new()
             .chain(b"SigEd25519 no Ed25519 collisions")

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -397,7 +397,13 @@ impl ExpandedSecretKey {
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
     pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
-        let mut h: Sha512 = Sha512::new();
+        self.sign_digest::<Sha512>(message, public_key)
+    }
+
+    /// Sign a message with this `ExpandedSecretKey` using the provided digest.
+    #[allow(non_snake_case)]
+    pub fn sign_digest<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
+        let mut h: D = D::new();
         let R: CompressedEdwardsY;
         let r: Scalar;
         let s: Scalar;
@@ -409,7 +415,7 @@ impl ExpandedSecretKey {
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
-        h = Sha512::new();
+        h = D::new();
         h.update(R.as_bytes());
         h.update(public_key.as_bytes());
         h.update(&message);

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -397,12 +397,19 @@ impl ExpandedSecretKey {
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
     pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
-        self.sign_digest::<Sha512>(message, public_key)
+        self.sign_digest_internal::<Sha512>(message, public_key)
     }
 
     /// Sign a message with this `ExpandedSecretKey` using the provided digest.
+    #[cfg(feature = "yolo_crypto")]
     #[allow(non_snake_case)]
     pub fn sign_digest<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
+        self.sign_digest_internal::<D>(message, public_key)
+    }
+
+    /// Internal method to sign a message with this `ExpandedSecretKey` generic over digest type.
+    #[allow(non_snake_case)]
+    fn sign_digest_internal<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
         let mut h: D = D::new();
         let R: CompressedEdwardsY;
         let r: Scalar;


### PR DESCRIPTION
apparently some folks like to use `ed25519` with other hashers (like `keccak` and `sha3`)... to use `dalek` in place of existing libraries exporting these functions one requires a mechanism for specifying the `digest` type.

this adds generic methods over a `Digest` for generating public keys and signing and verifying messages, and updates the existing API to call these to avoid duplication.