### PR TITLE
WIP: `alloc` free `verify_batch`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ serde_crate = { package = "serde", version = "1.0", default-features = false, op
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "~1.3", default-features = false }
+array-macro = "2.1.5"
+heapless = { version = "0.7.14", optional = true }
 
 [dev-dependencies]
 hex = "^0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ pub extern crate ed25519;
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 extern crate curve25519_dalek;
-#[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
+#[cfg(any(feature = "batch", feature = "batch_deterministic"))]
 extern crate merlin;
 #[cfg(any(feature = "batch", feature = "std", feature = "alloc", test))]
 extern crate rand;
@@ -255,8 +255,8 @@ extern crate serde_crate as serde;
 extern crate sha2;
 extern crate zeroize;
 
-#[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
-mod batch;
+#[cfg(any(feature = "batch", feature = "batch_deterministic"))]
+pub mod batch;
 mod constants;
 mod keypair;
 mod errors;
@@ -266,7 +266,7 @@ mod signature;
 
 pub use curve25519_dalek::digest::Digest;
 
-#[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
+#[cfg(any(feature = "batch", feature = "batch_deterministic"))]
 pub use crate::batch::*;
 pub use crate::constants::*;
 pub use crate::errors::*;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -281,6 +281,33 @@ mod integrations {
         assert!(result.is_ok());
     }
 
+    #[cfg(all(feature = "batch", feature = "heapless"))]
+    #[test]
+    fn verify_batch_n_seven_signatures() {
+        let messages: [&[u8]; 7] = [
+            b"Watch closely everyone, I'm going to show you how to kill a god.",
+            b"I'm not a cryptographer I just encrypt a lot.",
+            b"Still not a cryptographer.",
+            b"This is a test of the tsunami alert system. This is only a test.",
+            b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
+            b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
+            b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
+        let mut csprng = OsRng{};
+        let mut keypairs: Vec<Keypair> = Vec::new();
+        let mut signatures: Vec<Signature> = Vec::new();
+
+        for i in 0..messages.len() {
+            let keypair: Keypair = Keypair::generate(&mut csprng);
+            signatures.push(keypair.sign(&messages[i]));
+            keypairs.push(keypair);
+        }
+        let public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public).collect();
+
+        let result = verify_batch_n::<8>(&messages, &signatures[..], &public_keys[..], 7);
+
+        assert!(result.is_ok());
+    }
+
     #[test]
     fn pubkey_from_secret_and_expanded_secret() {
         let mut csprng = OsRng{};


### PR DESCRIPTION
hi folks ^_^

this is the beginning of an allocation free implementation of `verify_batch` via `heapless`.

i've refactored the `batch` module to support this, but am currently blocked on the requirement for `alloc` in `VartimeMultiscalarMul` implementations for `EdwardsPoint` (see `scalar_mul::strauss` and `scalar_mul::pippenger` `optional_multiscalar_mul` functions for detail), and was wondering whether y'all had thoughts on how best to approach this?

cc. @isislovecruft 