### PR TITLE
restrict ExpandedSK::sign visibility to avoid pk oracle

### DIFF
--- a/benches/ed25519_benchmarks.rs
+++ b/benches/ed25519_benchmarks.rs
@@ -16,7 +16,7 @@ use criterion::Criterion;
 
 mod ed25519_benches {
     use super::*;
-    use ed25519_dalek::ExpandedSecretKey;
+    use ed25519_dalek::verify_batch;
     use ed25519_dalek::Keypair;
     use ed25519_dalek::PublicKey;
     use ed25519_dalek::Signature;
@@ -30,20 +30,7 @@ mod ed25519_benches {
         let keypair: Keypair = Keypair::generate(&mut csprng);
         let msg: &[u8] = b"";
 
-        c.bench_function("Ed25519 signing", move |b| {
-                         b.iter(| | keypair.sign(msg))
-        });
-    }
-
-    fn sign_expanded_key(c: &mut Criterion) {
-        let mut csprng: ThreadRng = thread_rng();
-        let keypair: Keypair = Keypair::generate(&mut csprng);
-        let expanded: ExpandedSecretKey = (&keypair.secret).into();
-        let msg: &[u8] = b"";
-        
-        c.bench_function("Ed25519 signing with an expanded secret key", move |b| {
-                         b.iter(| | expanded.sign(msg, &keypair.public))
-        });
+        c.bench_function("Ed25519 signing", move |b| b.iter(|| keypair.sign(msg)));
     }
 
     fn verify(c: &mut Criterion) {
@@ -78,8 +65,10 @@ mod ed25519_benches {
                 let keypairs: Vec<Keypair> = (0..size).map(|_| Keypair::generate(&mut csprng)).collect();
                 let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
                 let messages: Vec<&[u8]> = (0..size).map(|_| msg).collect();
-                let signatures:  Vec<Signature> = keypairs.iter().map(|key| key.sign(&msg)).collect();
-                let public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public).collect();
+                let signatures: Vec<Signature> =
+                    keypairs.iter().map(|key| key.sign(&msg)).collect();
+                let public_keys: Vec<PublicKey> =
+                    keypairs.iter().map(|key| key.public_key()).collect();
 
                 b.iter(|| verify_batch(&messages[..], &signatures[..], &public_keys[..]));
             },
@@ -100,7 +89,6 @@ mod ed25519_benches {
         config = Criterion::default();
         targets =
             sign,
-            sign_expanded_key,
             verify,
             verify_strict,
             verify_batch_signatures,

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -209,7 +209,7 @@ fn zero_rng() -> ZeroRng {
 /// let msg: &[u8] = b"They're good dogs Brant";
 /// let messages: Vec<&[u8]> = (0..64).map(|_| msg).collect();
 /// let signatures:  Vec<Signature> = keypairs.iter().map(|key| key.sign(&msg)).collect();
-/// let public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public).collect();
+/// let public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public_key()).collect();
 ///
 /// let result = verify_batch(&messages[..], &signatures[..], &public_keys[..]);
 /// assert!(result.is_ok());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,8 @@ pub(crate) enum InternalError {
                       name_c: &'static str, length_c: usize, },
     /// An ed25519ph signature can only take up to 255 octets of context.
     PrehashedContextLengthError,
+    /// A mismatched (public, secret) key pair.
+    MismatchedKeypairError,
 }
 
 impl Display for InternalError {
@@ -63,6 +65,7 @@ impl Display for InternalError {
                               {} has length {}, {} has length {}.", na, la, nb, lb, nc, lc),
             InternalError::PrehashedContextLengthError
                 => write!(f, "An ed25519ph signature can only take up to 255 octets of context"),
+            InternalError::MismatchedKeypairError => write!(f, "Mismatched Keypair detected"),
         }
     }
 }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -35,12 +35,35 @@ use crate::secret::*;
 #[derive(Debug)]
 pub struct Keypair {
     /// The secret half of this keypair.
-    pub secret: SecretKey,
+    pub(crate) secret: SecretKey,
     /// The public half of this keypair.
-    pub public: PublicKey,
+    pub(crate) public: PublicKey,
+}
+
+impl From<SecretKey> for Keypair {
+    fn from(secret: SecretKey) -> Self {
+        let public = PublicKey::from(&secret);
+        Self { secret, public }
+    }
 }
 
 impl Keypair {
+    /// Public getter for the secret key of this keypair.
+    ///
+    /// # Returns
+    /// The secret key.
+    pub fn secret_key(&self) -> SecretKey {
+        SecretKey(self.secret.0)
+    }
+
+    /// Public getter for the public key of this keypair.
+    ///
+    /// # Returns
+    /// The public key.
+    pub fn public_key(&self) -> PublicKey {
+        self.public
+    }
+
     /// Convert this keypair to bytes.
     ///
     /// # Returns
@@ -303,7 +326,7 @@ impl Keypair {
     /// let mut prehashed_again: Sha512 = Sha512::default();
     /// prehashed_again.update(message);
     ///
-    /// let verified = keypair.public.verify_prehashed(prehashed_again, Some(context), &sig);
+    /// let verified = keypair.public_key().verify_prehashed(prehashed_again, Some(context), &sig);
     ///
     /// assert!(verified.is_ok());
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
-//! # let public_key: PublicKey = keypair.public;
+//! # let public_key: PublicKey = keypair.public_key();
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //!
 //! let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
@@ -213,7 +213,7 @@
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
-//! # let public_key: PublicKey = keypair.public;
+//! # let public_key: PublicKey = keypair.public_key();
 //! # let verified: bool = public_key.verify(message, &signature).is_ok();
 //! # let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
 //! # let encoded_signature: Vec<u8> = serialize(&signature).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
 //!
-//! let public_key: PublicKey = keypair.public;
+//! let public_key: PublicKey = keypair.public_key();
 //! assert!(public_key.verify(message, &signature).is_ok());
 //! # }
 //! ```
@@ -111,10 +111,9 @@
 //! # let keypair: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = keypair.sign(message);
-//! # let public_key: PublicKey = keypair.public;
 //!
-//! let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = public_key.to_bytes();
-//! let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair.secret.to_bytes();
+//! let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = keypair.public_key().to_bytes();
+//! let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair.secret_key().to_bytes();
 //! let keypair_bytes:    [u8; KEYPAIR_LENGTH]    = keypair.to_bytes();
 //! let signature_bytes:  [u8; SIGNATURE_LENGTH]  = signature.to_bytes();
 //! # }
@@ -127,6 +126,7 @@
 //! # extern crate ed25519_dalek;
 //! # use std::convert::TryFrom;
 //! # use rand::rngs::OsRng;
+//! # use std::convert::TryInto;
 //! # use ed25519_dalek::{Keypair, Signature, Signer, PublicKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), SignatureError> {
@@ -134,8 +134,8 @@
 //! # let keypair_orig: Keypair = Keypair::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature_orig: Signature = keypair_orig.sign(message);
-//! # let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = keypair_orig.public.to_bytes();
-//! # let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair_orig.secret.to_bytes();
+//! # let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] = keypair_orig.public_key().to_bytes();
+//! # let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = keypair_orig.secret_key().to_bytes();
 //! # let keypair_bytes:    [u8; KEYPAIR_LENGTH]    = keypair_orig.to_bytes();
 //! # let signature_bytes:  [u8; SIGNATURE_LENGTH]  = signature_orig.to_bytes();
 //! #
@@ -234,7 +234,6 @@
 #![no_std]
 #![warn(future_incompatible)]
 #![deny(missing_docs)] // refuse to compile if documentation is missing
-
 #![cfg_attr(not(test), forbid(unsafe_code))]
 
 #[cfg(any(feature = "std", test))]

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -396,7 +396,7 @@ impl ExpandedSecretKey {
 
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
-    pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
+    pub(crate) fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
         let mut h: Sha512 = Sha512::new();
         let R: CompressedEdwardsY;
         let r: Scalar;
@@ -441,7 +441,7 @@ impl ExpandedSecretKey {
     ///
     /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
     #[allow(non_snake_case)]
-    pub fn sign_prehashed<'a, D>(
+    pub(crate) fn sign_prehashed<'a, D>(
         &self,
         prehashed_message: D,
         public_key: &PublicKey,

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -239,7 +239,7 @@ impl<'d> Deserialize<'d> for SecretKey {
 // same signature scheme, and which both fail in exactly the same way.  For a
 // better-designed, Schnorr-based signature scheme, see Trevor Perrin's work on
 // "generalised EdDSA" and "VXEdDSA".
-pub struct ExpandedSecretKey {
+pub(crate) struct ExpandedSecretKey {
     pub(crate) key: Scalar,
     pub(crate) nonce: [u8; 32],
 }
@@ -256,7 +256,7 @@ impl<'a> From<&'a SecretKey> for ExpandedSecretKey {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;
@@ -302,7 +302,7 @@ impl ExpandedSecretKey {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;
@@ -342,7 +342,7 @@ impl ExpandedSecretKey {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// # extern crate rand;
     /// # extern crate sha2;
     /// # extern crate ed25519_dalek;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -375,12 +375,13 @@ impl ExpandedSecretKey {
     /// # fn main() { }
     /// ```
     #[inline]
-    pub fn from_bytes(bytes: &[u8]) -> Result<ExpandedSecretKey, SignatureError> {
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<ExpandedSecretKey, SignatureError> {
         if bytes.len() != EXPANDED_SECRET_KEY_LENGTH {
             return Err(InternalError::BytesLengthError {
                 name: "ExpandedSecretKey",
                 length: EXPANDED_SECRET_KEY_LENGTH,
-            }.into());
+            }
+            .into());
         }
         let mut lower: [u8; 32] = [0u8; 32];
         let mut upper: [u8; 32] = [0u8; 32];
@@ -546,5 +547,16 @@ mod test {
         let memory: &[u8] = unsafe { ::std::slice::from_raw_parts(secret_ptr, 32) };
 
         assert!(!memory.contains(&0x15));
+    }
+
+    #[test]
+    fn pubkey_from_secret_and_expanded_secret() {
+        let mut csprng = rand::rngs::OsRng {};
+        let secret: SecretKey = SecretKey::generate(&mut csprng);
+        let expanded_secret: ExpandedSecretKey = (&secret).into();
+        let public_from_secret: PublicKey = (&secret).into(); // XXX eww
+        let public_from_expanded_secret: PublicKey = (&expanded_secret).into(); // XXX eww
+
+        assert!(public_from_secret == public_from_expanded_secret);
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -508,28 +508,6 @@ impl ExpandedSecretKey {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Serialize for ExpandedSecretKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let bytes = &self.to_bytes()[..];
-        SerdeBytes::new(bytes).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'d> Deserialize<'d> for ExpandedSecretKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'d>,
-    {
-        let bytes = <SerdeByteBuf>::deserialize(deserializer)?;
-        ExpandedSecretKey::from_bytes(bytes.as_ref()).map_err(SerdeError::custom)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -283,17 +283,6 @@ mod integrations {
 
         assert!(result.is_ok());
     }
-
-    #[test]
-    fn pubkey_from_secret_and_expanded_secret() {
-        let mut csprng = OsRng{};
-        let secret: SecretKey = SecretKey::generate(&mut csprng);
-        let expanded_secret: ExpandedSecretKey = (&secret).into();
-        let public_from_secret: PublicKey = (&secret).into(); // XXX eww
-        let public_from_expanded_secret: PublicKey = (&expanded_secret).into(); // XXX eww
-
-        assert!(public_from_secret == public_from_expanded_secret);
-    }
 }
 
 #[serde(crate = "serde_crate")]

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -394,28 +394,6 @@ mod serialisation {
     }
 
     #[test]
-    fn serialize_deserialize_expanded_secret_key_bincode() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
-        let encoded_expanded_secret_key: Vec<u8> = bincode::serialize(&expanded_secret_key).unwrap();
-        let decoded_expanded_secret_key: ExpandedSecretKey = bincode::deserialize(&encoded_expanded_secret_key).unwrap();
-
-        for i in 0..EXPANDED_SECRET_KEY_LENGTH {
-            assert_eq!(expanded_secret_key.to_bytes()[i], decoded_expanded_secret_key.to_bytes()[i]);
-        }
-    }
-
-    #[test]
-    fn serialize_deserialize_expanded_secret_key_json() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
-        let encoded_expanded_secret_key = serde_json::to_string(&expanded_secret_key).unwrap();
-        let decoded_expanded_secret_key: ExpandedSecretKey = serde_json::from_str(&encoded_expanded_secret_key).unwrap();
-
-        for i in 0..EXPANDED_SECRET_KEY_LENGTH {
-            assert_eq!(expanded_secret_key.to_bytes()[i], decoded_expanded_secret_key.to_bytes()[i]);
-        }
-    }
-
-    #[test]
     fn serialize_deserialize_keypair_bincode() {
         let keypair = Keypair::from_bytes(&KEYPAIR_BYTES).unwrap();
         let encoded_keypair: Vec<u8> = bincode::serialize(&keypair).unwrap();
@@ -463,13 +441,10 @@ mod serialisation {
     #[test]
     fn serialize_secret_key_size() {
         let secret_key: SecretKey = SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap();
-        assert_eq!(bincode::serialized_size(&secret_key).unwrap() as usize, BINCODE_INT_LENGTH + SECRET_KEY_LENGTH);
-    }
-
-    #[test]
-    fn serialize_expanded_secret_key_size() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
-        assert_eq!(bincode::serialized_size(&expanded_secret_key).unwrap() as usize, BINCODE_INT_LENGTH + EXPANDED_SECRET_KEY_LENGTH);
+        assert_eq!(
+            bincode::serialized_size(&secret_key).unwrap() as usize,
+            BINCODE_INT_LENGTH + SECRET_KEY_LENGTH
+        );
     }
 
     #[test]

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -29,7 +29,6 @@ use sha2::Sha512;
 #[cfg(test)]
 mod vectors {
     use curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar};
-    use ed25519::signature::Signature as _;
     use sha2::{digest::Digest, Sha512};
     use std::convert::TryFrom;
 
@@ -69,8 +68,10 @@ mod vectors {
             let sig_bytes: Vec<u8> = FromHex::from_hex(&parts[3]).unwrap();
 
             let secret: SecretKey = SecretKey::from_bytes(&sec_bytes[..SECRET_KEY_LENGTH]).unwrap();
-            let public: PublicKey = PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
-            let keypair: Keypair  = Keypair{ secret: secret, public: public };
+            let expected_public: PublicKey =
+                PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
+            let keypair: Keypair = Keypair::from(secret);
+            assert_eq!(expected_public, keypair.public_key());
 
 		    // The signatures in the test vectors also include the message
 		    // at the end, but we just want R and S.
@@ -97,8 +98,10 @@ mod vectors {
         let sig_bytes: Vec<u8> = FromHex::from_hex(signature).unwrap();
 
         let secret: SecretKey = SecretKey::from_bytes(&sec_bytes[..SECRET_KEY_LENGTH]).unwrap();
-        let public: PublicKey = PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
-        let keypair: Keypair  = Keypair{ secret: secret, public: public };
+        let expected_public: PublicKey =
+            PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
+        let keypair: Keypair = Keypair::from(secret);
+        assert_eq!(expected_public, keypair.public_key());
         let sig1: Signature = Signature::from_bytes(&sig_bytes[..]).unwrap();
 
         let mut prehash_for_signing: Sha512 = Sha512::default();


### PR DESCRIPTION
The least disruptive API changes might be turn `ExpandedSecretKey::sign_*()` to `pub(crate)`, leaving only the correct `KeyPair.sign_*()` API for signing to public invocation, which is always correct and not vulnerable to "[Signing Function Oracle](https://github.com/MystenLabs/ed25519-unsafe-libs)" attack.