### PR TITLE
Add methods to support non-sha512 digests via generic types with defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,5 @@ legacy_compatibility = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
+# This feature exposes unverified internals for compatibility with non-spec-compliant 25519 implementations
+yolo_crypto = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,7 @@ mod secret;
 mod signature;
 
 pub use curve25519_dalek::digest::Digest;
+use curve25519_dalek::digest::generic_array::typenum::U64;
 
 #[cfg(all(any(feature = "batch", feature = "batch_deterministic"), any(feature = "std", feature = "alloc")))]
 pub use crate::batch::*;
@@ -277,3 +278,11 @@ pub use crate::secret::*;
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
 pub use ed25519::signature::{Signer, Verifier};
 pub use ed25519::Signature;
+
+
+
+/// Helper trait for digests with 512 bit outputs
+pub trait Digest512: curve25519_dalek::digest::Digest<OutputSize = U64> {}
+
+/// Implemented on all `Digest512<OutputSize = U64>` types
+impl <T: curve25519_dalek::digest::Digest<OutputSize = U64>> Digest512 for T {}

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -397,7 +397,13 @@ impl ExpandedSecretKey {
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
     pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
-        let mut h: Sha512 = Sha512::new();
+        self.sign_digest::<Sha512>(message, public_key)
+    }
+
+    /// Sign a message with this `ExpandedSecretKey` using the provided digest.
+    #[allow(non_snake_case)]
+    pub fn sign_digest<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
+        let mut h: D = D::new();
         let R: CompressedEdwardsY;
         let r: Scalar;
         let s: Scalar;
@@ -409,7 +415,7 @@ impl ExpandedSecretKey {
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
-        h = Sha512::new();
+        h = D::new();
         h.update(R.as_bytes());
         h.update(public_key.as_bytes());
         h.update(&message);

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -397,12 +397,19 @@ impl ExpandedSecretKey {
     /// Sign a message with this `ExpandedSecretKey`.
     #[allow(non_snake_case)]
     pub fn sign(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
-        self.sign_digest::<Sha512>(message, public_key)
+        self.sign_digest_internal::<Sha512>(message, public_key)
     }
 
     /// Sign a message with this `ExpandedSecretKey` using the provided digest.
+    #[cfg(feature = "yolo_crypto")]
     #[allow(non_snake_case)]
     pub fn sign_digest<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
+        self.sign_digest_internal::<D>(message, public_key)
+    }
+
+    /// Internal method to sign a message with this `ExpandedSecretKey` generic over digest type.
+    #[allow(non_snake_case)]
+    fn sign_digest_internal<D: Digest<OutputSize=U64>>(&self, message: &[u8], public_key: &PublicKey) -> ed25519::Signature {
         let mut h: D = D::new();
         let R: CompressedEdwardsY;
         let r: Scalar;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -70,7 +70,7 @@ mod vectors {
 
             let secret: SecretKey = SecretKey::from_bytes(&sec_bytes[..SECRET_KEY_LENGTH]).unwrap();
             let public: PublicKey = PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
-            let keypair: Keypair  = Keypair{ secret: secret, public: public };
+            let keypair: Keypair  = Keypair::from((secret, public));
 
 		    // The signatures in the test vectors also include the message
 		    // at the end, but we just want R and S.
@@ -98,7 +98,7 @@ mod vectors {
 
         let secret: SecretKey = SecretKey::from_bytes(&sec_bytes[..SECRET_KEY_LENGTH]).unwrap();
         let public: PublicKey = PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
-        let keypair: Keypair  = Keypair{ secret: secret, public: public };
+        let keypair: Keypair  = Keypair::from((secret, public ));
         let sig1: Signature = Signature::from_bytes(&sig_bytes[..]).unwrap();
 
         let mut prehash_for_signing: Sha512 = Sha512::default();
@@ -177,7 +177,7 @@ mod vectors {
         }
 
         let signature = serialize_signature(&r, &s);
-        let pk = PublicKey::from_bytes(&pub_key.compress().as_bytes()[..]).unwrap();
+        let pk = <PublicKey>::from_bytes(&pub_key.compress().as_bytes()[..]).unwrap();
         let sig = Signature::try_from(&signature[..]).unwrap();
         // The same signature verifies for both messages
         assert!(pk.verify(message1, &sig).is_ok() && pk.verify(message2, &sig).is_ok());
@@ -403,7 +403,7 @@ mod serialisation {
 
     #[test]
     fn serialize_deserialize_expanded_secret_key_bincode() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        let expanded_secret_key: ExpandedSecretKey = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
         let encoded_expanded_secret_key: Vec<u8> = bincode::serialize(&expanded_secret_key).unwrap();
         let decoded_expanded_secret_key: ExpandedSecretKey = bincode::deserialize(&encoded_expanded_secret_key).unwrap();
 
@@ -414,7 +414,7 @@ mod serialisation {
 
     #[test]
     fn serialize_deserialize_expanded_secret_key_json() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        let expanded_secret_key = <ExpandedSecretKey>::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
         let encoded_expanded_secret_key = serde_json::to_string(&expanded_secret_key).unwrap();
         let decoded_expanded_secret_key: ExpandedSecretKey = serde_json::from_str(&encoded_expanded_secret_key).unwrap();
 
@@ -476,7 +476,7 @@ mod serialisation {
 
     #[test]
     fn serialize_expanded_secret_key_size() {
-        let expanded_secret_key = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
+        let expanded_secret_key: ExpandedSecretKey = ExpandedSecretKey::from(&SecretKey::from_bytes(&SECRET_KEY_BYTES).unwrap());
         assert_eq!(bincode::serialized_size(&expanded_secret_key).unwrap() as usize, BINCODE_INT_LENGTH + EXPANDED_SECRET_KEY_LENGTH);
     }
 


### PR DESCRIPTION
As an alternative to the implementation in https://github.com/dalek-cryptography/ed25519-dalek/pull/201 (including unsafe methods), cc. @isislovecruft 

- Outstanding [bug](https://github.com/rust-lang/rust/issues/69035) in generic resolution means you sometimes need to call `<Type>::...` rather than `Type::...` which may be breaking for some consumers
- Addition of `_d: PhantomData<DIGEST>` to `KeyPair` means `let k =
  Keypair{ public: _, private: _ }` is no longer viable, added an alternative `From<(PublicKey, SecretKey)>` to compensate but this is definitely breaking due to the exposed struct internals