### PR TITLE
add feature for enabling/disabling inclusion of basepoint tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ harness = false
 # required-features = ["batch"]
 
 [features]
-default = ["std", "rand", "u64_backend"]
+default = ["std", "rand", "u64_backend", "basepoint_tables"]
 std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek/nightly"]
@@ -63,3 +63,6 @@ legacy_compatibility = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
+
+# Enable use of basepoint tables for accelerated operations
+basepoint_tables = ["curve25519-dalek/basepoint_tables"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,3 +277,13 @@ pub use crate::secret::*;
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
 pub use ed25519::signature::{Signer, Verifier};
 pub use ed25519::Signature;
+
+// Internal re-export [`ED25519_BASEPOINT`] using table or point depending 
+// `basepoint_tables` feature, internally this should be used in place of 
+// `_TABLE` or `_POINT`.
+
+#[cfg(feature="basepoint_tables")]
+pub(crate) use curve25519_dalek::constants::{ED25519_BASEPOINT_TABLE as ED25519_BASEPOINT};
+
+#[cfg(not(feature="basepoint_tables"))]
+pub(crate) use curve25519_dalek::constants::{ED25519_BASEPOINT_POINT as ED25519_BASEPOINT};

--- a/src/public.rs
+++ b/src/public.rs
@@ -154,7 +154,7 @@ impl PublicKey {
         bits[31] &= 127;
         bits[31] |= 64;
 
-        let point = &Scalar::from_bits(*bits) * &constants::ED25519_BASEPOINT_TABLE;
+        let point = &Scalar::from_bits(*bits) * &crate::ED25519_BASEPOINT;
         let compressed = point.compress();
 
         PublicKey(compressed, point)

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -407,7 +407,7 @@ impl ExpandedSecretKey {
         h.update(&message);
 
         r = Scalar::from_hash(h);
-        R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
+        R = (&r * &crate::ED25519_BASEPOINT).compress();
 
         h = Sha512::new();
         h.update(R.as_bytes());
@@ -489,7 +489,7 @@ impl ExpandedSecretKey {
             .chain(&prehash[..]);
 
         r = Scalar::from_hash(h);
-        R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
+        R = (&r * &crate::ED25519_BASEPOINT).compress();
 
         h = Sha512::new()
             .chain(b"SigEd25519 no Ed25519 collisions")


### PR DESCRIPTION
allows basepoint tables to be excluded to reduce flash usage on embedded devices.

this should have no impact on most users, but will require adding `features = [ "basepoint_tables" ]` for any folks with `default_features=false`.

depends on https://github.com/dalek-cryptography/curve25519-dalek/pull/402

cc. @isislovecruft 