### PR TITLE
Add Keypair::from::<SecretKey>

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -40,6 +40,14 @@ pub struct Keypair {
     pub public: PublicKey,
 }
 
+impl From<SecretKey> for Keypair {
+    /// Derive this keypair from its corresponding `SecretKey`.
+    fn from(secret_key: SecretKey) -> Keypair {
+        let public_key = PublicKey::from(&secret_key);
+        Keypair { secret: secret_key, public: public_key }
+    }
+}
+
 impl Keypair {
     /// Convert this keypair to bytes.
     ///


### PR DESCRIPTION
I felt this method was missing, as `Keypair` is the most useful type for signing - it should be easy to construct.

Perhaps a `Keypair::from_secret_bytes` would be good as well, to create a `Keypair` directly from the minimal required amount of information?