### PR TITLE
Update rand libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ features = ["nightly", "batch"]
 curve25519-dalek = { version = "3", default-features = false }
 ed25519 = { version = "1", default-features = false }
 merlin = { version = "2", default-features = false, optional = true }
-rand = { version = "0.7", default-features = false, optional = true }
-rand_core = { version = "0.5", default-features = false, optional = true }
+rand = { version = "0.8.5", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.9", default-features = false }


### PR DESCRIPTION
`rand_core` is usually not compatible cross version, upgrading it here so it is usable with crates that use `rand >= 0.8`