### PR TITLE
`ed25519` v2.0.0-pre.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = ["nightly", "batch"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-pre.2", default-features = false }
-ed25519 = { version = "1", default-features = false }
+ed25519 = { version = "=2.0.0-pre.0", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false, optional = true }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -14,7 +14,6 @@ use core::fmt::Debug;
 
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
-use ed25519::signature::Signature as _;
 
 use crate::constants::*;
 use crate::errors::*;
@@ -194,7 +193,7 @@ impl TryFrom<&ed25519::Signature> for InternalSignature {
     type Error = SignatureError;
 
     fn try_from(sig: &ed25519::Signature) -> Result<InternalSignature, SignatureError> {
-        InternalSignature::from_bytes(sig.as_bytes())
+        InternalSignature::from_bytes(sig.as_ref())
     }
 }
 


### PR DESCRIPTION
Bumps the `ed25519` crate to the v2.0.0-pre.0 prerelease.

This version notably uses the `signature` crate's v2 API:

https://github.com/RustCrypto/traits/pull/1141