### PR TITLE
Bump `curve25519-dalek` to v4.0.0-pre (via git)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,41 +4,29 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ 'main', 'develop', 'release/2.0' ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test-u32:
-    name: Test u32 backend
+  test:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-default-features --features "std u32_backend"
+    strategy:
+      matrix:
+        include:
+          # 32-bit target
+          - target: i686-unknown-linux-gnu
+            deps: sudo apt update && sudo apt install gcc-multilib
 
-  test-u64:
-    name: Test u64 backend
-    runs-on: ubuntu-latest
+          # 64-bit target
+          - target: x86_64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-default-features --features "std u64_backend"
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup target add ${{ matrix.target }}
+      - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }}
 
   test-simd:
     name: Test simd backend (nightly)
@@ -71,7 +59,7 @@ jobs:
         args: --features "serde"
 
   test-alloc-u32:
-    name: Test no_std+alloc with u32 backend
+    name: Test no_std+alloc
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -83,7 +71,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --lib --no-default-features --features "alloc u32_backend"
+        args: --lib --no-default-features --features "alloc"
 
   test-batch-deterministic:
     name: Test deterministic batch verification

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "3", default-features = false }
+curve25519-dalek = { version = "=4.0.0-pre.2", default-features = false }
 ed25519 = { version = "1", default-features = false }
-merlin = { version = "2", default-features = false, optional = true }
-rand = { version = "0.7", default-features = false, optional = true }
-rand_core = { version = "0.5", default-features = false, optional = true }
+merlin = { version = "3", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
@@ -37,7 +37,7 @@ hex = "^0.4"
 bincode = "1.0"
 serde_json = "1.0"
 criterion = "0.3"
-rand = "0.7"
+rand = "0.8"
 serde_crate = { package = "serde", version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
 
@@ -49,7 +49,7 @@ harness = false
 # required-features = ["batch"]
 
 [features]
-default = ["std", "rand", "u64_backend"]
+default = ["std", "rand"]
 std = ["curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek/nightly"]
@@ -60,6 +60,7 @@ batch_deterministic = ["merlin", "rand", "rand_core"]
 asm = ["sha2/asm"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
-u64_backend = ["curve25519-dalek/u64_backend"]
-u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "release/4.0" }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -482,24 +482,24 @@ impl ExpandedSecretKey {
         // This is a really fucking stupid bandaid, and the damned scheme is
         // still bleeding from malleability, for fuck's sake.
         h = Sha512::new()
-            .chain(b"SigEd25519 no Ed25519 collisions")
-            .chain(&[1]) // Ed25519ph
-            .chain(&[ctx_len])
-            .chain(ctx)
-            .chain(&self.nonce)
-            .chain(&prehash[..]);
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update(&[1]) // Ed25519ph
+            .chain_update(&[ctx_len])
+            .chain_update(ctx)
+            .chain_update(&self.nonce)
+            .chain_update(&prehash[..]);
 
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
         h = Sha512::new()
-            .chain(b"SigEd25519 no Ed25519 collisions")
-            .chain(&[1]) // Ed25519ph
-            .chain(&[ctx_len])
-            .chain(ctx)
-            .chain(R.as_bytes())
-            .chain(public_key.as_bytes())
-            .chain(&prehash[..]);
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update(&[1]) // Ed25519ph
+            .chain_update(&[ctx_len])
+            .chain_update(ctx)
+            .chain_update(R.as_bytes())
+            .chain_update(public_key.as_bytes())
+            .chain_update(&prehash[..]);
 
         k = Scalar::from_hash(h);
         s = &(&k * &self.key) + &r;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -127,9 +127,9 @@ mod vectors {
 
     fn compute_hram(message: &[u8], pub_key: &EdwardsPoint, signature_r: &EdwardsPoint) -> Scalar {
         let k_bytes = Sha512::default()
-            .chain(&signature_r.compress().as_bytes())
-            .chain(&pub_key.compress().as_bytes()[..])
-            .chain(&message);
+            .chain_update(&signature_r.compress().as_bytes())
+            .chain_update(&pub_key.compress().as_bytes()[..])
+            .chain_update(&message);
         let mut k_output = [0u8; 64];
         k_output.copy_from_slice(k_bytes.finalize().as_slice());
         Scalar::from_bytes_mod_order_wide(&k_output)


### PR DESCRIPTION
Also bumps these corresponding dependencies which are needed for everything to compile with this update:

- `merlin` v3.0
- `rand` v0.8
- `rand_core` v0.6
- `sha2` v0.10