### PR TITLE
Tune up CI configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,6 @@ jobs:
           # 32-bit target
           - target: i686-unknown-linux-gnu
             deps: sudo apt update && sudo apt install gcc-multilib
-
           # 64-bit target
           - target: x86_64-unknown-linux-gnu
     steps:
@@ -27,94 +26,38 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add ${{ matrix.target }}
       - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc
       - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features batch
+      - run: cargo test --target ${{ matrix.target }} --features batch_deterministic
+      - run: cargo test --target ${{ matrix.target }} --features serde
 
   test-simd:
     name: Test simd backend (nightly)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-default-features --features "std nightly simd_backend"
-
-  test-defaults-serde:
-    name: Test default feature selection and serde
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features "serde"
-
-  test-alloc-u32:
-    name: Test no_std+alloc
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --lib --no-default-features --features "alloc"
-
-  test-batch-deterministic:
-    name: Test deterministic batch verification
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features "batch_deterministic"
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo test --features simd_backend
 
   msrv:
     name: Current MSRV is 1.56.1
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: 1.56.1
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
+    - uses: actions/checkout@v3
+      # First run `cargo +nightly -Z minimal-verisons check` in order to get a
+      # Cargo.lock with the oldest possible deps
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo -Z minimal-versions check --no-default-features --features serde
+      # Now check that `cargo build` works with respect to the oldest possible
+      # deps and the stated MSRV
+    - uses: dtolnay/rust-toolchain@1.56.1
+    - run: cargo build
 
   bench:
     name: Check that benchmarks compile
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        # This filter selects no benchmarks, so we don't run any, only build them.
-        args: --features "batch" "nonexistentbenchmark"
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --benches --features batch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,7 @@ toml = { version = "0.5" }
 [[bench]]
 name = "ed25519_benchmarks"
 harness = false
-# This doesn't seem to work with criterion, cf. https://github.com/bheisler/criterion.rs/issues/344
-# For now, we have to bench by doing `cargo bench --features="batch"`.
-# required-features = ["batch"]
+required-features = ["batch"]
 
 [features]
 default = ["std", "rand"]


### PR DESCRIPTION
- Consolidate `test` jobs: this allows reusing intermediate artifacts between tests which should improve build times, and also make it easier to test additional features in the future
- Switch to `dtolnay/rust-toolchain` for setting up toolchain
- Bump checkout to `actions/checkout@3`
- Switch to `run` directives for invoking Cargo: it's more straightforward to just call Cargo than use a DSL from an unmaintained action, and eliminates the 3rd party dependency