### PR TITLE
Change from_bytes methods to take fixed-size array argument

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -162,30 +162,12 @@ impl InternalSignature {
     /// only checking the most significant three bits.  (See also the
     /// documentation for `PublicKey.verify_strict`.)
     #[inline]
-    pub fn from_bytes(bytes: &[u8]) -> Result<InternalSignature, SignatureError> {
-        if bytes.len() != SIGNATURE_LENGTH {
-            return Err(InternalError::BytesLengthError {
-                name: "Signature",
-                length: SIGNATURE_LENGTH,
-            }
-            .into());
-        }
-        let mut lower: [u8; 32] = [0u8; 32];
-        let mut upper: [u8; 32] = [0u8; 32];
-
-        lower.copy_from_slice(&bytes[..32]);
-        upper.copy_from_slice(&bytes[32..]);
-
-        let s: Scalar;
-
-        match check_scalar(upper) {
-            Ok(x) => s = x,
-            Err(x) => return Err(x),
-        }
-
+    pub fn from_bytes(bytes: &[u8; SIGNATURE_LENGTH]) -> Result<InternalSignature, SignatureError> {
+        // TODO: Use bytes.split_array_ref once it’s in MSRV.
+        let (lower, upper) = bytes.split_at(32);
         Ok(InternalSignature {
-            R: CompressedEdwardsY(lower),
-            s: s,
+            R: CompressedEdwardsY(lower.try_into().unwrap()),
+            s: check_scalar(upper.try_into().unwrap())?,
         })
     }
 }

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -122,17 +122,10 @@ impl SigningKey {
     /// is an `SignatureError` describing the error that occurred.
     #[inline]
     pub fn from_keypair_bytes(bytes: &[u8; 64]) -> Result<SigningKey, SignatureError> {
-        if bytes.len() != KEYPAIR_LENGTH {
-            return Err(InternalError::BytesLengthError {
-                name: "SigningKey",
-                length: KEYPAIR_LENGTH,
-            }
-            .into());
-        }
-
-        let secret_key =
-            SecretKey::try_from(&bytes[..SECRET_KEY_LENGTH]).map_err(|_| SignatureError::new())?;
-        let verifying_key = VerifyingKey::from_bytes(&bytes[SECRET_KEY_LENGTH..])?;
+        // TODO: Use bytes.split_array_ref once it’s in MSRV.
+        let (secret_key, verifying_key) = bytes.split_at(SECRET_KEY_LENGTH);
+        let secret_key = secret_key.try_into().unwrap();
+        let verifying_key = VerifyingKey::from_bytes(verifying_key.try_into().unwrap())?;
 
         if verifying_key != VerifyingKey::from(&secret_key) {
             return Err(InternalError::MismatchedKeypairError.into());


### PR DESCRIPTION
Change from_bytes methods of all the types to take `&[u8; N]` argument
(with `N` appropriate for given type) rather than `&[u8]`.  This does
a few things:
- it makes SecretKey::from_bytes infallible which will simplify call
  sites (if the call site already has properly-sized array),
- harmonises the convention with ed25519::Signature::from_bytes method
  and
- encodes the size of the bytes representation in type system which
  means that users can assert it at compile time.

To still allow creating the objects from a slice whose size is checked
at run time, introduce `TryFrom<&[u8]>` implementations for affected
public types.

This is an API breaking change.  The simplest way to update existing
code is to replace Foo::from_bytes with Foo::try_from.  This should
cover majority of uses.
