### PR TITLE
Cargo.toml: compatibility updates for `curve25519-dalek` and `ed25519`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,11 +39,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
       - env:
-          RUSTFLAGS: "-C target_feature=+avx2"
-        run: cargo build --target x86_64-unknown-linux-gnu --features simd_backend
+          RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" -C target_feature=+avx2'
+        run: cargo build --target x86_64-unknown-linux-gnu
       - env:
-          RUSTFLAGS: "-C target_feature=+avx512ifma"
-        run: cargo build --target x86_64-unknown-linux-gnu --features simd_backend
+          RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" -C target_feature=+avx512ifma'
+        run: cargo build --target x86_64-unknown-linux-gnu
 
   msrv:
     name: Current MSRV is 1.56.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-pre.2", default-features = false }
+curve25519-dalek = { version = "=4.0.0-pre.2", default-features = false, features = ["digest", "rand_core"] }
 ed25519 = { version = "=2.0.0-pre.0", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
@@ -48,9 +48,8 @@ required-features = ["batch"]
 
 [features]
 default = ["std", "rand"]
-std = ["alloc", "curve25519-dalek/std", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
+std = ["alloc", "ed25519/std", "serde_crate/std", "sha2/std", "rand/std"]
 alloc = ["curve25519-dalek/alloc", "rand/alloc", "zeroize/alloc"]
-nightly = ["curve25519-dalek/nightly"]
 serde = ["serde_crate", "serde_bytes", "ed25519/serde"]
 batch = ["alloc", "merlin", "rand/std"]
 # This feature enables deterministic batch verification.
@@ -58,7 +57,7 @@ batch_deterministic = ["alloc", "merlin", "rand", "rand_core"]
 asm = ["sha2/asm"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
-simd_backend = ["curve25519-dalek/simd_backend"]
 
 [patch.crates-io]
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "release/4.0" }
+ed25519 = { git = "https://github.com/RustCrypto/signatures.git"}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -194,7 +194,7 @@ impl TryFrom<&ed25519::Signature> for InternalSignature {
     type Error = SignatureError;
 
     fn try_from(sig: &ed25519::Signature) -> Result<InternalSignature, SignatureError> {
-        InternalSignature::from_bytes(sig.as_ref())
+        InternalSignature::from_bytes(&sig.to_bytes())
     }
 }
 

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -69,7 +69,7 @@ mod vectors {
 
             // The signatures in the test vectors also include the message
             // at the end, but we just want R and S.
-            let sig1: Signature = Signature::from_bytes(&sig_bytes[..64]).unwrap();
+            let sig1: Signature = Signature::try_from(&sig_bytes[..64]).unwrap();
             let sig2: Signature = keypair.sign(&msg_bytes);
 
             assert!(sig1 == sig2, "Signature bytes not equal on line {}", lineno);
@@ -99,7 +99,7 @@ mod vectors {
             PublicKey::from_bytes(&pub_bytes[..PUBLIC_KEY_LENGTH]).unwrap();
         let keypair: Keypair = Keypair::from(secret);
         assert_eq!(expected_public, keypair.public_key());
-        let sig1: Signature = Signature::from_bytes(&sig_bytes[..]).unwrap();
+        let sig1: Signature = Signature::try_from(&sig_bytes[..]).unwrap();
 
         let mut prehash_for_signing: Sha512 = Sha512::default();
         let mut prehash_for_verifying: Sha512 = Sha512::default();


### PR DESCRIPTION
This PR contains the necessary updates for `ed25519-dalek` to be compatible with upstream `curve25519-dalek` and `ed25519` as sourced from git.

# curve25519-dalek:

- Enables `digest` and `rand_core` features
- Removes transitive `nightly`, `simd_backend`, and `std` features

# ed25519:

- `AsRef` impl for `Signature` has been removed; uses `to_bytes`
- Uses `try_from` for `InternalSignature` conversion