### PR TITLE
Propagate CtOption and ZERO from curve/4.0

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -94,7 +94,7 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
         return Ok(Scalar::from_bits(bytes));
     }
 
-    match Scalar::from_canonical_bytes(bytes) {
+    match Scalar::from_canonical_bytes(bytes).into() {
         None => return Err(InternalError::ScalarFormatError.into()),
         Some(x) => return Ok(x),
     };

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -156,7 +156,7 @@ mod vectors {
         fn non_null_scalar() -> Scalar {
             let mut rng = rand::rngs::OsRng;
             let mut s_candidate = Scalar::random(&mut rng);
-            while s_candidate == Scalar::zero() {
+            while s_candidate == Scalar::ZERO {
                 s_candidate = Scalar::random(&mut rng);
             }
             s_candidate


### PR DESCRIPTION
- Assuming check_scalar does not have to be CT I used dirty .into() ?

