### PR TITLE
Fix `SigningKey` from/to_bytes docs +coverage

### DIFF
--- a/src/signing.rs
+++ b/src/signing.rs
@@ -58,40 +58,36 @@ pub struct SigningKey {
     pub(crate) verifying_key: VerifyingKey,
 }
 
+/// # Example
+///
+/// ```
+/// # extern crate ed25519_dalek;
+/// #
+/// use ed25519_dalek::SigningKey;
+/// use ed25519_dalek::SECRET_KEY_LENGTH;
+/// use ed25519_dalek::SignatureError;
+///
+/// # fn doctest() -> Result<SigningKey, SignatureError> {
+/// let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = [
+///    157, 097, 177, 157, 239, 253, 090, 096,
+///    186, 132, 074, 244, 146, 236, 044, 196,
+///    068, 073, 197, 105, 123, 050, 105, 025,
+///    112, 059, 172, 003, 028, 174, 127, 096, ];
+///
+/// let signing_key: SigningKey = SigningKey::from_bytes(&secret_key_bytes);
+/// assert_eq!(signing_key.to_bytes(), secret_key_bytes);
+///
+/// # Ok(signing_key)
+/// # }
+/// #
+/// # fn main() {
+/// #     let result = doctest();
+/// #     assert!(result.is_ok());
+/// # }
+/// ```
 impl SigningKey {
-    /// Construct a [`SigningKey`] from a slice of bytes.
+    /// Construct a [`SigningKey`] from a [`SecretKey`]
     ///
-    /// # Example
-    ///
-    /// ```
-    /// # extern crate ed25519_dalek;
-    /// #
-    /// use ed25519_dalek::SigningKey;
-    /// use ed25519_dalek::SECRET_KEY_LENGTH;
-    /// use ed25519_dalek::SignatureError;
-    ///
-    /// # fn doctest() -> Result<SigningKey, SignatureError> {
-    /// let secret_key_bytes: [u8; SECRET_KEY_LENGTH] = [
-    ///    157, 097, 177, 157, 239, 253, 090, 096,
-    ///    186, 132, 074, 244, 146, 236, 044, 196,
-    ///    068, 073, 197, 105, 123, 050, 105, 025,
-    ///    112, 059, 172, 003, 028, 174, 127, 096, ];
-    ///
-    /// let signing_key: SigningKey = SigningKey::from_bytes(&secret_key_bytes);
-    /// #
-    /// # Ok(signing_key)
-    /// # }
-    /// #
-    /// # fn main() {
-    /// #     let result = doctest();
-    /// #     assert!(result.is_ok());
-    /// # }
-    /// ```
-    ///
-    /// # Returns
-    ///
-    /// A `Result` whose okay value is an EdDSA `SecretKey` or whose error value
-    /// is an `SignatureError` wrapping the internal error that occurred.
     #[inline]
     pub fn from_bytes(secret_key: &SecretKey) -> Self {
         let verifying_key = VerifyingKey::from(&ExpandedSecretKey::from(secret_key));
@@ -101,7 +97,7 @@ impl SigningKey {
         }
     }
 
-    /// Convert this secret key to a byte array.
+    /// Convert this [`SigningKey`] into a [`SecretKey`]
     #[inline]
     pub fn to_bytes(&self) -> SecretKey {
         self.secret_key


### PR DESCRIPTION
cargo +nightly tarpaulin --run-types Tests,Doctests

from/to_bytes docs needed adjusting + cheap coverage additions

Dec 18 18:03:59.714  INFO cargo_tarpaulin::report: Coverage Results:
```
|| Uncovered Lines:
|| src/errors.rs: 57-62, 64, 79, 83
|| src/lib.rs: 279
|| src/signature.rs: 55-56, 61-62, 68, 75-76, 79, 84, 97-99, 111, 167-169, 171, 179, 183
|| src/signing.rs: 106-107, 124-128, 130, 133-135, 137-138, 141-143, 157-158, 160-161, 464, 469, 474, 493-494, 500-501, 507-508, 518-519, 600, 610-611, 763-766, 771-772, 794, 797, 805, 808
|| src/verifying.rs: 46-47, 52-53, 59-62, 64-65, 67, 87-88, 134-136, 138, 198-199, 304, 313-315, 317-318, 320-321, 323, 361-362, 423, 433-434
|| Tested/Total Lines:
|| src/errors.rs: 2/11
|| src/lib.rs: 0/1
|| src/signature.rs: 21/40
|| src/signing.rs: 73/117
|| src/verifying.rs: 59/92
|| 
```
59.39% coverage, 155/261 lines covered

```
|| Uncovered Lines:
|| src/errors.rs: 57-62, 64, 79, 83
|| src/lib.rs: 279
|| src/signature.rs: 55-56, 61-62, 68, 75-76, 79, 84, 97-99, 111, 167-169, 171, 179, 183
|| src/signing.rs: 124-128, 130, 133-135, 137-138, 141-143, 464, 469, 474, 493-494, 500-501, 507-508, 518-519, 600, 610-611, 763-766, 771-772, 794, 797, 805, 808
|| src/verifying.rs: 46-47, 52-53, 59-62, 64-65, 67, 94, 134-136, 138, 198-199, 304, 313-315, 317-318, 320-321, 323, 361-362, 423, 433-434
|| Tested/Total Lines:
|| src/errors.rs: 2/11 +2.80%
|| src/lib.rs: 4/5 +80.00%
|| src/signature.rs: 21/40 +0.00%
|| src/signing.rs: 81/119
|| src/verifying.rs: 62/94
|| 
```
63.20% coverage, 170/269 lines covered, +4.66% change in coverage
