### PR TITLE
Impl `Drop`/`ZeroizeOnDrop` for `SigningKey`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.10", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
 hex = "^0.4"

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -32,7 +32,7 @@ use curve25519_dalek::scalar::Scalar;
 
 use ed25519::signature::{KeypairRef, Signer, Verifier};
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::constants::*;
 use crate::errors::*;
@@ -524,6 +524,14 @@ impl TryFrom<&[u8]> for SigningKey {
             })
     }
 }
+
+impl Drop for SigningKey {
+    fn drop(&mut self) {
+        self.secret_key.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SigningKey {}
 
 #[cfg(feature = "pkcs8")]
 impl DecodePrivateKey for SigningKey {}


### PR DESCRIPTION
- Zeros out `SigningKey::secret_key` on drop
- Adds the `ZeroizeOnDrop` marker trait to `SigningKey`