### PR TITLE
Add on-by-default `fast` crate feature for gating basepoint tables

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,9 +35,10 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc,fast,rand_core --lib --tests
       - run: cargo test --target ${{ matrix.target }}
       - run: cargo test --target ${{ matrix.target }} --features batch
-      - run: cargo test --target ${{ matrix.target }} --features "digest rand_core"
+      - run: cargo test --target ${{ matrix.target }} --features digest,rand_core
       - run: cargo test --target ${{ matrix.target }} --features serde
       - run: cargo test --target ${{ matrix.target }} --features pem
+      - run: cargo test --target ${{ matrix.target }} --all-features
 
   build-simd:
     name: Test simd backend (nightly)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --no-default-features --lib
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --lib --tests
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc --lib
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features fast --lib
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features rand_core --lib --tests
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc,rand_core --lib --tests
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features fast,rand_core --lib --tests
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc,fast,rand_core --lib --tests
       - run: cargo test --target ${{ matrix.target }}
       - run: cargo test --target ${{ matrix.target }} --features batch
       - run: cargo test --target ${{ matrix.target }} --features serde

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.0.0-pre.5"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git#83f6b149d33c37b8997316cb7a87d8d247b75c3e"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git#3effd73307a606e44469a425974f0b7b0eb85899"
 dependencies = [
  "cfg-if",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,13 @@ name = "ed25519_benchmarks"
 harness = false
 
 [features]
-default = ["std", "rand_core", "zeroize"]
+default = ["fast", "std", "rand_core", "zeroize"]
 alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
 std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
 asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
+fast = ["curve25519-dalek/basepoint-tables"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
 pkcs8 = ["ed25519/pkcs8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
 asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
-fast = ["curve25519-dalek/basepoint-tables"]
+fast = ["curve25519-dalek/precomputed-tables"]
 digest = []
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []


### PR DESCRIPTION
~~*NOTE: depends on https://github.com/dalek-cryptography/curve25519-dalek/pull/489 which needs to be merged first*~~ Merged!

~~*NOTE: now depends on #260 which needs to be merged first*~~ Merged!

Disabling the feature reduces overall code size at the cost of performance, which is useful for e.g. embedded users.

This feature transitively enables the `basepoint-tables` feature in `curve25519-dalek`.

~~TODO: fallback support for using variable-base scalar multiplication by the basepoint when the `basepoint-tables` feature is disabled.~~ Added in 8f56c5c