### PR TITLE
Impl `From<&SigningKey>` for `VerifyingKey`

### DIFF
--- a/src/signing.rs
+++ b/src/signing.rs
@@ -118,22 +118,18 @@ impl SigningKey {
     /// is an `SignatureError` describing the error that occurred.
     #[inline]
     pub fn from_keypair_bytes(bytes: &[u8; 64]) -> Result<SigningKey, SignatureError> {
-        // TODO: Use bytes.split_array_ref once it’s in MSRV.
         let (secret_key, verifying_key) = bytes.split_at(SECRET_KEY_LENGTH);
-        let secret_key = secret_key.try_into().unwrap();
-        let verifying_key = VerifyingKey::from_bytes(verifying_key.try_into().unwrap())?;
+        let signing_key = SigningKey::try_from(secret_key)?;
+        let verifying_key = VerifyingKey::try_from(verifying_key)?;
 
-        if verifying_key != VerifyingKey::from(&secret_key) {
+        if signing_key.verifying_key() != verifying_key {
             return Err(InternalError::MismatchedKeypair.into());
         }
 
-        Ok(SigningKey {
-            secret_key,
-            verifying_key,
-        })
+        Ok(signing_key)
     }
 
-    /// Convert this signing key to bytes.
+    /// Convert this signing key to a 64-byte keypair.
     ///
     /// # Returns
     ///
@@ -544,19 +540,19 @@ impl TryFrom<&pkcs8::KeypairBytes> for SigningKey {
     type Error = pkcs8::Error;
 
     fn try_from(pkcs8_key: &pkcs8::KeypairBytes) -> pkcs8::Result<Self> {
-        // Validate the public key in the PKCS#8 document if present
-        if let Some(public_bytes) = pkcs8_key.public_key {
-            let expected_verifying_key = VerifyingKey::from(&pkcs8_key.secret_key);
+        let signing_key = SigningKey::from_bytes(&pkcs8_key.secret_key);
 
-            let pkcs8_verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
+        // Validate the public key in the PKCS#8 document if present
+        if let Some(public_bytes) = &pkcs8_key.public_key {
+            let expected_verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
                 .map_err(|_| pkcs8::Error::KeyMalformed)?;
 
-            if expected_verifying_key != pkcs8_verifying_key {
+            if signing_key.verifying_key() != expected_verifying_key {
                 return Err(pkcs8::Error::KeyMalformed);
             }
         }
 
-        Ok(SigningKey::from_bytes(&pkcs8_key.secret_key))
+        Ok(signing_key)
     }
 }
 

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -54,30 +54,17 @@ impl AsRef<[u8]> for VerifyingKey {
     }
 }
 
-impl From<&SecretKey> for VerifyingKey {
-    /// Derive this public key from its corresponding `SecretKey`.
-    fn from(secret_key: &SecretKey) -> VerifyingKey {
-        let mut h: Sha512 = Sha512::new();
-        let mut hash: [u8; 64] = [0u8; 64];
-        let mut digest: [u8; 32] = [0u8; 32];
-
-        h.update(secret_key);
-        hash.copy_from_slice(h.finalize().as_slice());
-
-        digest.copy_from_slice(&hash[..32]);
-
-        VerifyingKey::mangle_scalar_bits_and_multiply_by_basepoint_to_produce_public_key(
-            &mut digest,
-        )
-    }
-}
-
 impl From<&ExpandedSecretKey> for VerifyingKey {
     /// Derive this public key from its corresponding `ExpandedSecretKey`.
     fn from(expanded_secret_key: &ExpandedSecretKey) -> VerifyingKey {
         let mut bits: [u8; 32] = expanded_secret_key.key.to_bytes();
-
         VerifyingKey::mangle_scalar_bits_and_multiply_by_basepoint_to_produce_public_key(&mut bits)
+    }
+}
+
+impl From<&SigningKey> for VerifyingKey {
+    fn from(signing_key: &SigningKey) -> VerifyingKey {
+        signing_key.verifying_key()
     }
 }
 


### PR DESCRIPTION
Calls the inherent `SigningKey::verifying_key` method using `From` conversions.

This replaces vestigial impl for `SecretKey` which is now an alias for `[u8; 32]`.