### PR TITLE
Bump `ed25519` crate to v2.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = ["nightly", "batch", "pkcs8"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-pre.3", default-features = false, features = ["digest", "rand_core"] }
-ed25519 = { version = "=2.0.0-rc.0", default-features = false }
+ed25519 = { version = "=2.0.0-rc.1", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }


### PR DESCRIPTION
This transitively updates `signature` to v2.0.0-rc.1, which contains RNG API changes which don't impact `ed25519-dalek`, as it doesn't use or enable the RNG API.