### PR TITLE
Bump `ed25519` crate dependency to v2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3af5919f6d605315213c36abdd435562224665993b274912dee0d9a0e2fed8a"
+checksum = "3cf420a7ec85d98495b0c34aa4a58ca117f982ffbece111aeb545160148d7010"
 dependencies = [
  "pkcs8",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = ["nightly", "batch", "pkcs8"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = ["digest"] }
-ed25519 = { version = "2", default-features = false }
+ed25519 = { version = "2.1", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -101,16 +101,6 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
 }
 
 impl InternalSignature {
-    /// Convert this `Signature` to a byte array.
-    #[inline]
-    pub fn as_bytes(&self) -> [u8; SIGNATURE_LENGTH] {
-        let mut signature_bytes: [u8; SIGNATURE_LENGTH] = [0u8; SIGNATURE_LENGTH];
-
-        signature_bytes[..32].copy_from_slice(&self.R.as_bytes()[..]);
-        signature_bytes[32..].copy_from_slice(&self.s.as_bytes()[..]);
-        signature_bytes
-    }
-
     /// Construct a `Signature` from a slice of bytes.
     ///
     /// # Scalar Malleability Checking
@@ -182,10 +172,7 @@ impl TryFrom<&ed25519::Signature> for InternalSignature {
 }
 
 impl From<InternalSignature> for ed25519::Signature {
-    #[allow(clippy::unwrap_used)]
     fn from(sig: InternalSignature) -> ed25519::Signature {
-        // This function only fails if the s half of the parsed input exceeds the scalar modulus.
-        // Since the bytes are coming straight from a Scalar, this is impossible.
-        ed25519::Signature::from_bytes(&sig.as_bytes()).unwrap()
+        ed25519::Signature::from_components(*sig.R.as_bytes(), *sig.s.as_bytes())
     }
 }

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -496,7 +496,7 @@ mod serialisation {
 
     #[test]
     fn serialize_deserialize_signature_bincode() {
-        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES);
         let encoded_signature: Vec<u8> = bincode::serialize(&signature).unwrap();
         let decoded_signature: Signature = bincode::deserialize(&encoded_signature).unwrap();
 
@@ -505,7 +505,7 @@ mod serialisation {
 
     #[test]
     fn serialize_deserialize_signature_json() {
-        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES);
         let encoded_signature = serde_json::to_string(&signature).unwrap();
         let decoded_signature: Signature = serde_json::from_str(&encoded_signature).unwrap();
 
@@ -582,7 +582,7 @@ mod serialisation {
 
     #[test]
     fn serialize_signature_size() {
-        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES);
         assert_eq!(
             bincode::serialized_size(&signature).unwrap() as usize,
             SIGNATURE_LENGTH

--- a/tests/validation_criteria.rs
+++ b/tests/validation_criteria.rs
@@ -84,7 +84,7 @@ impl From<IntermediateTestVector> for TestVector {
         let sig = {
             let mut buf = [0u8; 64];
             buf.copy_from_slice(&tv.sig);
-            Signature::from_bytes(&buf).unwrap()
+            Signature::from_bytes(&buf)
         };
         let msg = tv.msg.as_bytes().to_vec();
 


### PR DESCRIPTION
The original v2.0.0 release has been yanked.

This release includes a different infallible parsing API which can be used to eliminate some usages of `unwrap()`.