### PR TITLE
Add `Context` type

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,8 +2,8 @@ use crate::{InternalError, SignatureError};
 
 /// Ed25519 contexts as used by Ed25519ph.
 ///
-/// Contexts are domain separator strings that can be used to separate uses of
-/// the protocol between different protocols (which is very hard to reliably do
+/// Contexts are domain separator strings that can be used to isolate uses of
+/// the algorithm between different protocols (which is very hard to reliably do
 /// otherwise) and between different uses within the same protocol.
 ///
 /// To create a context, call either of the following:

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,46 @@
+use crate::{InternalError, SignatureError};
+
+/// Ed25519 contexts as used by Ed25519ctx and Ed25519ph.
+///
+/// Contexts are domain separator strings that can be used to separate uses of
+/// the protocol between different protocols (which is very hard to reliably do
+/// otherwise) and between different uses within the same protocol.
+///
+/// To create a context, call either of the following:
+///
+/// - [`SigningKey::with_context`](crate::SigningKey::with_context)
+/// - [`VerifyingKey::with_context`](crate::VerifyingKey::with_context)
+///
+/// For more information, see [RFC8032 § 8.3](https://www.rfc-editor.org/rfc/rfc8032#section-8.3).
+#[derive(Clone, Debug)]
+pub struct Context<'k, 'v, K> {
+    /// Key this context is being used with.
+    key: &'k K,
+
+    /// Context value: a bytestring no longer than 255 octets.
+    value: &'v [u8],
+}
+
+impl<'k, 'v, K> Context<'k, 'v, K> {
+    /// Maximum length of the context value in octets.
+    pub const MAX_LENGTH: usize = 255;
+
+    /// Create a new Ed25519ctx/Ed25519ph context.
+    pub(crate) fn new(key: &'k K, value: &'v [u8]) -> Result<Self, SignatureError> {
+        if value.len() <= Self::MAX_LENGTH {
+            Ok(Self { key, value })
+        } else {
+            Err(SignatureError::from(InternalError::PrehashedContextLength))
+        }
+    }
+
+    /// Borrow the key.
+    pub fn key(&self) -> &'k K {
+        self.key
+    }
+
+    /// Borrow the context string value.
+    pub fn value(&self) -> &'v [u8] {
+        self.value
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,10 +18,9 @@ use crate::{InternalError, SignatureError};
 #[cfg_attr(feature = "digest", doc = "```")]
 #[cfg_attr(not(feature = "digest"), doc = "```ignore")]
 /// # fn main() {
-/// # use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
+/// use ed25519_dalek::{Signature, SigningKey, VerifyingKey, Sha512};
 /// # use curve25519_dalek::digest::Digest;
 /// # use rand::rngs::OsRng;
-/// # use sha2::Sha512;
 /// use ed25519_dalek::{DigestSigner, DigestVerifier};
 ///
 /// # let mut csprng = OsRng;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use crate::{InternalError, SignatureError};
 
-/// Ed25519 contexts as used by Ed25519ctx and Ed25519ph.
+/// Ed25519 contexts as used by Ed25519ph.
 ///
 /// Contexts are domain separator strings that can be used to separate uses of
 /// the protocol between different protocols (which is very hard to reliably do
@@ -55,7 +55,7 @@ impl<'k, 'v, K> Context<'k, 'v, K> {
     /// Maximum length of the context value in octets.
     pub const MAX_LENGTH: usize = 255;
 
-    /// Create a new Ed25519ctx/Ed25519ph context.
+    /// Create a new Ed25519ph context.
     pub(crate) fn new(key: &'k K, value: &'v [u8]) -> Result<Self, SignatureError> {
         if value.len() <= Self::MAX_LENGTH {
             Ok(Self { key, value })

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,6 @@ pub(crate) enum InternalError {
         length_c: usize,
     },
     /// An ed25519ph signature can only take up to 255 octets of context.
-    #[cfg(feature = "digest")]
     PrehashedContextLength,
     /// A mismatched (public, secret) key pair.
     MismatchedKeypair,
@@ -77,7 +76,6 @@ impl Display for InternalError {
                               {} has length {}, {} has length {}.",
                 na, la, nb, lb, nc, lc
             ),
-            #[cfg(feature = "digest")]
             InternalError::PrehashedContextLength => write!(
                 f,
                 "An ed25519ph signature can only take up to 255 octets of context"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! # use ed25519_dalek::Signature;
 //! # use ed25519_dalek::Signer;
 //! use ed25519_dalek::{VerifyingKey, Verifier};
-//! # let mut csprng = OsRng{};
+//! # let mut csprng = OsRng;
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -97,7 +97,7 @@
 //! # use rand::rngs::OsRng;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # let mut csprng = OsRng{};
+//! # let mut csprng = OsRng;
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -266,6 +266,8 @@ mod verifying;
 
 #[cfg(feature = "digest")]
 pub use curve25519_dalek::digest::Digest;
+#[cfg(feature = "digest")]
+pub use sha2::Sha512;
 
 #[cfg(feature = "batch")]
 pub use crate::batch::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,8 @@ pub use crate::signing::*;
 pub use crate::verifying::*;
 
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
+#[cfg(feature = "digest")]
+pub use ed25519::signature::{DigestSigner, DigestVerifier};
 pub use ed25519::signature::{Signer, Verifier};
 pub use ed25519::Signature;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,7 @@ pub use ed25519;
 #[cfg(feature = "batch")]
 mod batch;
 mod constants;
+mod context;
 mod errors;
 mod signature;
 mod signing;
@@ -269,6 +270,7 @@ pub use curve25519_dalek::digest::Digest;
 #[cfg(feature = "batch")]
 pub use crate::batch::*;
 pub use crate::constants::*;
+pub use crate::context::Context;
 pub use crate::errors::*;
 pub use crate::signing::*;
 pub use crate::verifying::*;

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -210,9 +210,7 @@ impl SigningKey {
     ///
     /// # Inputs
     ///
-    /// * `prehashed_message` is an instantiated hash digest with 512-bits of
-    ///   output which has had the message to be signed previously fed into its
-    ///   state.
+    /// * `prehashed_message` is an instantiated SHA-512 digest of the message
     /// * `context` is an optional context string, up to 255 bytes inclusive,
     ///   which may be used to provide additional domain separation.  If not
     ///   set, this will default to an empty string.
@@ -220,6 +218,13 @@ impl SigningKey {
     /// # Returns
     ///
     /// An Ed25519ph [`Signature`] on the `prehashed_message`.
+    ///
+    /// # Note
+    ///
+    /// The RFC only permits SHA-512 to be used for prehashing. This function technically works,
+    /// and is probably safe to use, with any secure hash function with 512-bit digests, but
+    /// anything outside of SHA-512 is NOT specification-compliant. We expose [`crate::Sha512`] for
+    /// user convenience.
     ///
     /// # Examples
     ///
@@ -236,7 +241,7 @@ impl SigningKey {
     ///
     /// # #[cfg(feature = "std")]
     /// # fn main() {
-    /// let mut csprng = OsRng{};
+    /// let mut csprng = OsRng;
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
@@ -284,7 +289,7 @@ impl SigningKey {
     /// # use rand::rngs::OsRng;
     /// #
     /// # fn do_test() -> Result<Signature, SignatureError> {
-    /// # let mut csprng = OsRng{};
+    /// # let mut csprng = OsRng;
     /// # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// # let message: &[u8] = b"All I want is to pet all of the dogs.";
     /// # let mut prehashed: Sha512 = Sha512::new();
@@ -358,7 +363,7 @@ impl SigningKey {
     /// use rand::rngs::OsRng;
     ///
     /// # fn do_test() -> Result<(), SignatureError> {
-    /// let mut csprng = OsRng{};
+    /// let mut csprng = OsRng;
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
@@ -495,6 +500,12 @@ impl Signer<Signature> for SigningKey {
 }
 
 /// Equivalent to [`SigningKey::sign_prehashed`] with `context` set to [`None`].
+///
+/// # Note
+///
+/// The RFC only permits SHA-512 to be used for prehashing. This function technically works, and is
+/// probably safe to use, with any secure hash function with 512-bit digests, but anything outside
+/// of SHA-512 is NOT specification-compliant. We expose [`crate::Sha512`] for user convenience.
 #[cfg(feature = "digest")]
 impl<D> DigestSigner<D, Signature> for SigningKey
 where
@@ -507,6 +518,12 @@ where
 
 /// Equivalent to [`SigningKey::sign_prehashed`] with `context` set to [`Some`]
 /// containing `self.value()`.
+///
+/// # Note
+///
+/// The RFC only permits SHA-512 to be used for prehashing. This function technically works, and is
+/// probably safe to use, with any secure hash function with 512-bit digests, but anything outside
+/// of SHA-512 is NOT specification-compliant. We expose [`crate::Sha512`] for user convenience.
 #[cfg(feature = "digest")]
 impl<D> DigestSigner<D, Signature> for Context<'_, '_, SigningKey>
 where

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -506,7 +506,7 @@ where
 }
 
 /// Equivalent to [`SigningKey::sign_prehashed`] with `context` set to [`Some`]
-/// containing [`Context::value`].
+/// containing `self.value()`.
 #[cfg(feature = "digest")]
 impl<D> DigestSigner<D, Signature> for Context<'_, '_, SigningKey>
 where

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -442,7 +442,7 @@ where
 }
 
 /// Equivalent to [`VerifyingKey::verify_prehashed`] with `context` set to [`Some`]
-/// containing [`Context::value`].
+/// containing `self.value()`.
 #[cfg(feature = "digest")]
 impl<D> DigestVerifier<D, ed25519::Signature> for Context<'_, '_, VerifyingKey>
 where

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -38,6 +38,7 @@ use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 use signature::DigestVerifier;
 
 use crate::constants::*;
+use crate::context::Context;
 use crate::errors::*;
 use crate::signature::*;
 use crate::signing::*;
@@ -151,6 +152,15 @@ impl VerifyingKey {
 
         // Invariant: VerifyingKey.1 is always the decompression of VerifyingKey.0
         Ok(VerifyingKey(compressed, point))
+    }
+
+    /// Create a verifying context that can be used for Ed25519ph with
+    /// [`DigestVerifier`].
+    pub fn with_context<'k, 'v>(
+        &'k self,
+        context_value: &'v [u8],
+    ) -> Result<Context<'k, 'v, Self>, SignatureError> {
+        Context::new(self, context_value)
     }
 
     /// Internal utility function for clamping a scalar representation and multiplying by the
@@ -428,6 +438,23 @@ where
         signature: &ed25519::Signature,
     ) -> Result<(), SignatureError> {
         self.verify_prehashed(msg_digest, None, signature)
+    }
+}
+
+/// Equivalent to [`VerifyingKey::verify_prehashed`] with `context` set to [`Some`]
+/// containing [`Context::value`].
+#[cfg(feature = "digest")]
+impl<D> DigestVerifier<D, ed25519::Signature> for Context<'_, '_, VerifyingKey>
+where
+    D: Digest<OutputSize = U64>,
+{
+    fn verify_digest(
+        &self,
+        msg_digest: D,
+        signature: &ed25519::Signature,
+    ) -> Result<(), SignatureError> {
+        self.key()
+            .verify_prehashed(msg_digest, Some(self.value()), signature)
     }
 }
 


### PR DESCRIPTION
Adds a generic type which can be used with `SigningKey` and `VerifyingKey` for storing a context string value along with the key for use with `DigestSigner` and `DigestVerifier`.