### PR TITLE
README changes for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+Entries are listed in reverse chronological order per undeprecated major series.
 
-### Changes
-* Bumped MSRV from 1.41 to 1.60.0
-* Removed `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
-* Implemented `Clone` for `SigningKey`
+# 2.x series
+
+##  2.0.0
+
+### Breaking changes
+
+* Bump MSRV from 1.41 to 1.60.0
+* Bump Rust edition
+* Bump `signature` dependency to 2.0
+* Make `digest` an optional dependency
+* Make `zeroize` an optional dependency
+* Make `rand_core` an optional dependency
+* Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
+* Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
+* Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
+
+### Other changes
+
+* Add `Context` type for prehashed signing
+* Add `VerifyingKey::verify_prehash_strict`
+* Add `pkcs` feature to support PKCS #8 (de)serialization of `SigningKey` and `VerifyingKey`
+* Add `fast` feature to include basepoint tables
+* Add tests for validation criteria
+* Impl `DigestSigner`/`DigestVerifier` for `SigningKey`/`VerifyingKey`, respectively
+* Impl `Hash` for `VerifyingKey`
+* Impl `Clone`, `Drop`, and `ZeroizeOnDrop` for `SigningKey`
+* Remove `rand` dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 ### Other changes
 
 * Add `Context` type for prehashed signing
-* Add `VerifyingKey::verify_prehash_strict`
+* Add `VerifyingKey::{verify_prehash_strict, is_weak}`
 * Add `pkcs` feature to support PKCS #8 (de)serialization of `SigningKey` and `VerifyingKey`
 * Add `fast` feature to include basepoint tables
 * Add tests for validation criteria

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Bump MSRV from 1.41 to 1.60.0
 * Bump Rust edition
 * Bump `signature` dependency to 2.0
+* Make [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) more automatic
 * Make `digest` an optional dependency
 * Make `zeroize` an optional dependency
 * Make `rand_core` an optional dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to ed25519-dalek
+
+If you have questions or comments, please feel free to email the
+authors. 
+
+For feature requests, suggestions, and bug reports, please open an issue on
+[our Github](https://github.com/dalek-cryptography/ed25519-dalek).  (Or, send us
+an email if you're opposed to using Github for whatever reason.)
+
+Patches are welcomed as pull requests on
+[our Github](https://github.com/dalek-cryptography/ed25519-dalek), as well as by
+email (preferably sent to all of the authors listed in `Cargo.toml`).
+
+All issues on ed25519-dalek are mentored, if you want help with a bug just
+ask @tarcieri or @rozbb.
+
+Some issues are easier than others. The `easy` label can be used to find the
+easy issues. If you want to work on an issue, please leave a comment so that we
+can assign it to you!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0-pre.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,14 @@
 name = "ed25519-dalek"
 version = "1.0.1"
 edition = "2021"
-authors = ["isis lovecruft <isis@patternsinthevoid.net>"]
+authors = [
+    "isis lovecruft <isis@patternsinthevoid.net>",
+    "Tony Arcieri <bascule@gmail.com>",
+    "Michael Rosenberg <michael@mrosenberg.pub>"
+]
 readme = "README.md"
 license = "BSD-3-Clause"
 repository = "https://github.com/dalek-cryptography/ed25519-dalek"
-homepage = "https://dalek.rs"
 documentation = "https://docs.rs/ed25519-dalek"
 keywords = ["cryptography", "ed25519", "curve25519", "signature", "ECC"]
 categories = ["cryptography", "no-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0-pre.0"
 edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This crate is `#[no_std]` compatible with `default-features = false`
 | Feature                | Default? | Description |
 | :---                   | :---     | :---        |
 | `alloc`                | ✓        | Enables features that require dynamic heap allocation |
-| `std`                  | ✓        | std::error::Error types |
-| `zeroize`              | ✓        | Enables `Zeroize` for `SigningKey` |
-| `asm`                  |          | Assembly implementation of SHA-2 compression functions |
-| `batch`                |          | Batch verification. Requires `alloc` |
+| `std`                  | ✓        | Implements `std::error::Error` for `SignatureError` |
+| `zeroize`              | ✓        | Enables `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
+| `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
+| `batch`                |          | Enables `verify_batch` for verifying many signatures quickly |
 | `digest`               |          | TODO |
 | `legacy_compatibility` |          | See: A Note on Signature Malleability |
 | `pkcs8`                |          | PKCS#8 Support |

--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@ verification in Rust.
 
 # Use
 
-To use, add the following to your project's `Cargo.toml`:
+## Stable
 
+To import `ed25519-dalek`, add the following to the dependencies section of
+your project's `Cargo.toml`:
 ```toml
-[dependencies.ed25519-dalek]
-version = "1"
+ed25519-dalek = "1"
+```
+
+## Beta
+
+To use the latest prerelease (see changes [below](#breaking-changes-in-200)),
+use the following line in your project's `Cargo.toml`:
+```toml
+ed25519-dalek = "2.0.0-pre.0"
 ```
 
 # Feature Flags
@@ -33,7 +42,7 @@ This crate is `#[no_std]` compatible with `default-features = false`
 
 See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of this crate.
 
-## 2.0.0 Breaking Changes
+## Breaking Changes in 2.0.0
 
 * Bump MSRV from 1.41 to 1.60.0
 * Bump Rust edition
@@ -137,9 +146,9 @@ To address variety of  usage scenarios various backends are available that
 include hardware optimisations as well as a formally verified fiat crypto
 backend that does not use any hardware optimisations.
 
-These backends can be overriden with various configuration predicates (cfg)
+These backends can be overridden with various configuration predicates (cfg)
 
-Please see the [curve25519_dalek backend documentation](https://docs.rs/curve25519-dalek/latest/curve25519_dalek).
+Please see the [curve25519-dalek backend documentation](https://docs.rs/curve25519-dalek/latest/curve25519_dalek).
 
 # Contributing
 
@@ -166,7 +175,7 @@ If you need to interoperate with such implementations and accept otherwise inval
 
 Note: [CIRCL](https://github.com/cloudflare/circl/blob/fa6e0cca79a443d7be18ed241e779adf9ed2a301/sign/ed25519/ed25519.go#L358) has no scalar range check at all. We do not have a feature flag for interoperating with the larger set of RFC-disallowed signatures that CIRCL accepts.
 
-## Weakkey Forgery and `verify_strict()`
+## Weak key Forgery and `verify_strict()`
 
 A _signature forgery_ is what it sounds like: it's when an attacker, given a public key _A_, creates a signature _σ_ and message _m_ such that _σ_ is a valid signature of _m_ with respect to _A_. Since this is the core security definition of any signature scheme, Ed25519 signatures cannot be forged.
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ As mentioned above, weak public keys can be used to produce signatures for unkno
 
 Why is this? It's because `verify_batch()` does not do the weak key testing of `verify_strict()`, and it multiplies each verification equation by some random coefficient. If the failed forgery gets multiplied by 8, then the weak key (which is a low-order point) becomes 0, and the verification equation on the attempted forgery will succeed.
 
-Since `verify_batch()` is intended to be high-throughput, we think it's best not to put weak key checks in it. If you want to prevent weird behavior due to weak public keys in your batches,
-TODO
-you should call [`VerifyingKey::is_weak`][method_is_weak] on the inputs in advance.
+Since `verify_batch()` is intended to be high-throughput, we think it's best not to put weak key checks in it. If you want to prevent weird behavior due to weak public keys in your batches, you should call [`VerifyingKey::is_weak`][method_is_weak] on the inputs in advance.
 
 [fiat]: https://github.com/mit-plv/fiat-crypto
 [validation]: https://hdevalence.ca/blog/2020-10-04-its-25519am

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ This crate is `#[no_std]` compatible with `default-features = false`
 | :---                   | :---     | :---        |
 | `alloc`                | ✓        | Enables features that require dynamic heap allocation |
 | `std`                  | ✓        | Implements `std::error::Error` for `SignatureError` |
-| `zeroize`              | ✓        | Enables `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
+| `zeroize`              | ✓        | Implements `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
+| `rand_core`            |          | Enables `SigningKey::generate` |
+| `batch`                |          | Enables `verify_batch` for verifying many signatures quickly. Also enables `rand_core`. |
+| `digest`               |          | Enables `Context`, `SigningKey::{with_context, sign_prehashed}` and `VerifyingKey::{with_context, verify_prehashed, verify_prehashed_strict}` for Ed25519ph prehashed signatures |
 | `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
-| `batch`                |          | Enables `verify_batch` for verifying many signatures quickly |
-| `digest`               |          | Enables `Context` |
-| `legacy_compatibility` |          | See: A Note on Signature Malleability |
-| `pkcs8`                |          | PKCS#8 Support |
-| `pem`                  |          | PEM Support |
-| `rand_core`            |          | TODO        |
+| `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
+| `pem`                  |          | TODO: @tarcieri how is this different from `pkcs8`? |
+| `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [the section on malleability](#a-note-on-signature-malleability) |
 
 # Major Changes
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This crate is `#[no_std]` compatible with `default-features = false`
 | `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
 | `pem`                  |          | TODO |
-| `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [the section on malleability](#a-note-on-signature-malleability) |
+| `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |
 
 # Major Changes
 
@@ -162,7 +162,6 @@ A signature scheme is considered to produce _malleable signatures_ if a passive 
 `ed25519-dalek` is not a malleable signature scheme.
 
 Some other Ed25519 implementations are malleable, though, such as [libsodium with `ED25519_COMPAT` enabled](https://github.com/jedisct1/libsodium/blob/24211d370a9335373f0715664271dfe203c7c2cd/src/libsodium/crypto_sign/ed25519/ref10/open.c#L30), [ed25519-donna](https://github.com/floodyberry/ed25519-donna/blob/8757bd4cd209cb032853ece0ce413f122eef212c/ed25519.c#L100), [NaCl's ref10 impl](https://github.com/floodyberry/ed25519-donna/blob/8757bd4cd209cb032853ece0ce413f122eef212c/fuzz/ed25519-ref10.c#L4627), and probably a lot more.
-
 If you need to interoperate with such implementations and accept otherwise invalid signatures, you can enable the `legacy_compatibility` flag. **Do not enable `legacy_compatibility`** if you don't have to, because it will make your signatures malleable.
 
 Note: [CIRCL](https://github.com/cloudflare/circl/blob/fa6e0cca79a443d7be18ed241e779adf9ed2a301/sign/ed25519/ed25519.go#L358) has no scalar range check at all. We do not have a feature flag for interoperating with the larger set of RFC-disallowed signatures that CIRCL accepts.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ed25519-dalek [![](https://img.shields.io/crates/v/ed25519-dalek.svg)](https://crates.io/crates/ed25519-dalek) [![](https://docs.rs/ed25519-dalek/badge.svg)](https://docs.rs/ed25519-dalek) [![Rust](https://github.com/dalek-cryptography/ed25519-dalek/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/dalek-cryptography/ed25519-dalek/actions/workflows/rust.yml)
 
-some sneaky curve25519 references there :)
-
 Fast and efficient Rust implementation of ed25519 key generation, signing, and
 verification.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This crate is `#[no_std]` compatible with `default-features = false`
 | `zeroize`              | ✓        | Enables `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
 | `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
 | `batch`                |          | Enables `verify_batch` for verifying many signatures quickly |
-| `digest`               |          | TODO |
+| `digest`               |          | Enables `Context` |
 | `legacy_compatibility` |          | See: A Note on Signature Malleability |
 | `pkcs8`                |          | PKCS#8 Support |
 | `pem`                  |          | PEM Support |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ed25519-dalek [![](https://img.shields.io/crates/v/ed25519-dalek.svg)](https://crates.io/crates/ed25519-dalek) [![](https://docs.rs/ed25519-dalek/badge.svg)](https://docs.rs/ed25519-dalek) [![Rust](https://github.com/dalek-cryptography/curve25519-dalek/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/dalek-cryptography/curve25519-dalek/actions/workflows/rust.yml)
+# ed25519-dalek [![](https://img.shields.io/crates/v/ed25519-dalek.svg)](https://crates.io/crates/ed25519-dalek) [![](https://docs.rs/ed25519-dalek/badge.svg)](https://docs.rs/ed25519-dalek) [![Rust](https://github.com/dalek-cryptography/ed25519-dalek/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/dalek-cryptography/ed25519-dalek/actions/workflows/rust.yml)
+
+some sneaky curve25519 references there :)
 
 Fast and efficient Rust implementation of ed25519 key generation, signing, and
 verification.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | `digest`               |          | Enables `Context`, `SigningKey::{with_context, sign_prehashed}` and `VerifyingKey::{with_context, verify_prehashed, verify_prehashed_strict}` for Ed25519ph prehashed signatures |
 | `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
-| `pem`                  |          | TODO |
+| `pem`                  |          | Enables PEM serialization support for PKCS#8 private keys and SPKI public keys. Also enables `alloc`. |
 | `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |
 
 # Major Changes

--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of t
 
 ## 2.0.0 Breaking Changes
 
-* Update the MSRV from 1.41 to 1.60
-* `batch` is now `batch_deterministic`
-* Removed `ExpandedSecretKey` API
-* [curve25519-backend selection] is more automatic
-
-[curve25519-backend selection]: https://github.com/dalek-cryptography/curve25519-dalek/#backends
+* Bump MSRV from 1.41 to 1.60.0
+* Bump Rust edition
+* Bump `signature` dependency to 2.0
+* Make [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) more automatic
+* Make `digest` an optional dependency
+* Make `zeroize` an optional dependency
+* Make `rand_core` an optional dependency
+* Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
+* Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
+* Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
 
 # Documentation
 
@@ -71,9 +75,11 @@ Below are the specific policies:
 | :---     | :---                    | :---   |
 | 2.x      | Dependencies `digest`, `pkcs8` and `rand_core` | Minor SemVer bump |
 
+TODO @tarcieri what about PEM?
+
 ## Safety
 
-This crate does not require any unsafe and forbids all unsafe in-crate outside tests.
+`ed25519-dalek` forbids `unsafe` in-crate outside tests.
 
 # Performance
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,8 +15,11 @@ use crate::{InternalError, SignatureError};
 ///
 /// # Example
 ///
-#[cfg_attr(feature = "digest", doc = "```")]
-#[cfg_attr(not(feature = "digest"), doc = "```ignore")]
+#[cfg_attr(all(feature = "digest", feature = "rand_core"), doc = "```")]
+#[cfg_attr(
+    any(not(feature = "digest"), not(feature = "rand_core")),
+    doc = "```ignore"
+)]
 /// # fn main() {
 /// use ed25519_dalek::{Signature, SigningKey, VerifyingKey, Sha512};
 /// # use curve25519_dalek::digest::Digest;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,6 +48,7 @@ pub(crate) enum InternalError {
         length_c: usize,
     },
     /// An ed25519ph signature can only take up to 255 octets of context.
+    #[cfg(feature = "digest")]
     PrehashedContextLength,
     /// A mismatched (public, secret) key pair.
     MismatchedKeypair,
@@ -76,6 +77,7 @@ impl Display for InternalError {
                               {} has length {}, {} has length {}.",
                 na, la, nb, lb, nc, lc
             ),
+            #[cfg(feature = "digest")]
             InternalError::PrehashedContextLength => write!(
                 f,
                 "An ed25519ph signature can only take up to 255 octets of context"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,8 @@
 //!
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
-//! # use std::convert::TryFrom;
+//! # use core::convert::{TryFrom, TryInto};
 //! # use rand::rngs::OsRng;
-//! # use std::convert::TryInto;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SigningKey, VerifyingKey, Signature), SignatureError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,7 @@ pub use ed25519;
 #[cfg(feature = "batch")]
 mod batch;
 mod constants;
+#[cfg(feature = "digest")]
 mod context;
 mod errors;
 mod signature;
@@ -271,6 +272,7 @@ pub use sha2::Sha512;
 #[cfg(feature = "batch")]
 pub use crate::batch::*;
 pub use crate::constants::*;
+#[cfg(feature = "digest")]
 pub use crate::context::Context;
 pub use crate::errors::*;
 pub use crate::signing::*;

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -172,21 +172,15 @@ impl SigningKey {
     ///
     /// # Example
     ///
-    /// ```
-    /// # #[cfg(feature = "std")]
+    #[cfg_attr(feature = "rand_core", doc = "```")]
+    #[cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
     /// # fn main() {
-    ///
     /// use rand::rngs::OsRng;
-    /// use ed25519_dalek::SigningKey;
-    /// use ed25519_dalek::Signature;
+    /// use ed25519_dalek::{Signature, SigningKey};
     ///
     /// let mut csprng = OsRng;
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
-    ///
     /// # }
-    /// #
-    /// # #[cfg(not(feature = "std"))]
-    /// # fn main() { }
     /// ```
     ///
     /// # Input
@@ -239,7 +233,6 @@ impl SigningKey {
     /// use sha2::Sha512;
     /// use rand::rngs::OsRng;
     ///
-    /// # #[cfg(feature = "std")]
     /// # fn main() {
     /// let mut csprng = OsRng;
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
@@ -250,9 +243,6 @@ impl SigningKey {
     ///
     /// prehashed.update(message);
     /// # }
-    /// #
-    /// # #[cfg(not(feature = "std"))]
-    /// # fn main() { }
     /// ```
     ///
     /// If you want, you can optionally pass a "context".  It is generally a
@@ -301,13 +291,9 @@ impl SigningKey {
     /// #
     /// # Ok(sig)
     /// # }
-    /// # #[cfg(feature = "std")]
     /// # fn main() {
     /// #     do_test();
     /// # }
-    /// #
-    /// # #[cfg(not(feature = "std"))]
-    /// # fn main() { }
     /// ```
     ///
     /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
@@ -385,13 +371,9 @@ impl SigningKey {
     /// # verified
     /// # }
     /// #
-    /// # #[cfg(feature = "std")]
     /// # fn main() {
     /// #     do_test();
     /// # }
-    /// #
-    /// # #[cfg(not(feature = "std"))]
-    /// # fn main() { }
     /// ```
     ///
     /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -34,13 +34,14 @@ use curve25519_dalek::scalar::Scalar;
 use ed25519::signature::{KeypairRef, Signer, Verifier};
 
 #[cfg(feature = "digest")]
+use crate::context::Context;
+#[cfg(feature = "digest")]
 use signature::DigestSigner;
 
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::constants::*;
-use crate::context::Context;
 use crate::errors::*;
 use crate::signature::*;
 use crate::verifying::*;
@@ -161,6 +162,7 @@ impl SigningKey {
 
     /// Create a signing context that can be used for Ed25519ph with
     /// [`DigestSigner`].
+    #[cfg(feature = "digest")]
     pub fn with_context<'k, 'v>(
         &'k self,
         context_value: &'v [u8],

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -35,10 +35,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 
 #[cfg(feature = "digest")]
+use crate::context::Context;
+#[cfg(feature = "digest")]
 use signature::DigestVerifier;
 
 use crate::constants::*;
-use crate::context::Context;
 use crate::errors::*;
 use crate::signature::*;
 use crate::signing::*;
@@ -156,6 +157,7 @@ impl VerifyingKey {
 
     /// Create a verifying context that can be used for Ed25519ph with
     /// [`DigestVerifier`].
+    #[cfg(feature = "digest")]
     pub fn with_context<'k, 'v>(
         &'k self,
         context_value: &'v [u8],


### PR DESCRIPTION
[Rendered](https://github.com/dalek-cryptography/ed25519-dalek/blob/b635fc717e2ebb6a9dedbe6413d7ede9cdd14d56/README.md)

Other changes:
* Feature-gated `Context` and `with_context` behind `digest`. No reason to have those if you can't use them.
* Bumped the version number to 2.0.0-pre.0
* Added a `CONTRIBUTING.md` and updated authors list in `Cargo.toml`