### PR TITLE
Bump `curve25519-dalek` to v4.0.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,8 +239,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.5"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git#3effd73307a606e44469a425974f0b7b0eb85899"
+version = "4.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
 dependencies = [
  "cfg-if",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = [
 features = ["nightly", "batch", "pkcs8"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = ["digest"] }
+curve25519-dalek = { version = "=4.0.0-rc.0", default-features = false, features = ["digest"] }
 ed25519 = { version = "2.1", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -35,7 +35,7 @@ serde_bytes = { version = "0.11", optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = ["digest", "rand_core"] }
+curve25519-dalek = { version = "=4.0.0-rc.0", default-features = false, features = ["digest", "rand_core"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"
@@ -67,6 +67,3 @@ pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
 serde = ["dep:serde", "serde_bytes", "ed25519/serde"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]
-
-[patch.crates-io.curve25519-dalek]
-git = "https://github.com/dalek-cryptography/curve25519-dalek.git"


### PR DESCRIPTION
Eliminates the `patch.crates-io` directive by using the latest RC release of `curve25519-dalek` on crates.io