### PR TITLE
Impl `VerifyingKey::is_weak`

### DIFF
--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -163,6 +163,15 @@ impl VerifyingKey {
         Context::new(self, context_value)
     }
 
+    /// Returns whether this is a _weak_ public key, i.e., if this public key has low order.
+    ///
+    /// A weak public key can be used to generate a siganture that's valid for almost every
+    /// message. [`Self::verify_strict`] denies weak keys, but if you want to check for this
+    /// property before verification, then use this method.
+    pub fn is_weak(&self) -> bool {
+        self.1.is_small_order()
+    }
+
     /// Internal utility function for clamping a scalar representation and multiplying by the
     /// basepont to produce a public key.
     fn clamp_and_mul_base(bits: [u8; 32]) -> VerifyingKey {

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -228,6 +228,9 @@ mod vectors {
         assert!(vk.verify(message1, &sig).is_ok());
         assert!(vk.verify(message2, &sig).is_ok());
 
+        // Check that this public key appears as weak
+        assert!(vk.is_weak());
+
         // Now check that the sigs fail under verify_strict. This is because verify_strict rejects
         // small order pubkeys.
         assert!(vk.verify_strict(message1, &sig).is_err());
@@ -305,6 +308,9 @@ mod integrations {
         let verifying_key = signing_key.verifying_key();
         good_sig = signing_key.sign(&good);
         bad_sig = signing_key.sign(&bad);
+
+        // Check that an honestly generated public key is not weak
+        assert!(!verifying_key.is_weak());
 
         assert!(
             signing_key.verify(&good, &good_sig).is_ok(),


### PR DESCRIPTION
`verify_strict` does this check, but it might be useful to users, especailly those of `verify_batch`, to do this check before verification. The README in #275 refers users to this method.

Partially resolves #188

Also note that this solution might be overridden by a more principled approach to strict verification—one that follows the algorithms specified in [this paper](https://eprint.iacr.org/2020/1244).