### PR TITLE
Remove invalid input fields from CI action for Rust setup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
-          profile: minimal
       - run: cargo doc --all-features


### PR DESCRIPTION
Neither `override` nor `profile` are valid inputs for the `dtolnay/rust-toolchain` action. It always uses the minimal profile anyways.

This PR gets rid of the warning

> Unexpected input(s) 'override', 'profile', valid inputs are ['toolchain', 'targets', 'target', 'components']

as seen in https://github.com/dalek-cryptography/ed25519-dalek/actions/runs/4092160926.