### PR TITLE
Bump `ed25519` to v2.2; `pkcs8` to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf420a7ec85d98495b0c34aa4a58ca117f982ffbece111aeb545160148d7010"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
  "pkcs8",
  "serde",
@@ -522,18 +522,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
 dependencies = [
  "der",
  "spki",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = ["batch", "pkcs8"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = ["digest"] }
-ed25519 = { version = "2.1", default-features = false }
+ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -10,7 +10,7 @@
 //! ed25519 signing keys.
 
 #[cfg(feature = "pkcs8")]
-use ed25519::pkcs8::{self, DecodePrivateKey};
+use ed25519::pkcs8;
 
 #[cfg(any(test, feature = "rand_core"))]
 use rand_core::CryptoRngCore;
@@ -564,9 +564,6 @@ impl Drop for SigningKey {
 
 #[cfg(feature = "zeroize")]
 impl ZeroizeOnDrop for SigningKey {}
-
-#[cfg(feature = "pkcs8")]
-impl DecodePrivateKey for SigningKey {}
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 impl pkcs8::EncodePrivateKey for SigningKey {

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -25,7 +25,7 @@ use ed25519::signature::Verifier;
 use sha2::Sha512;
 
 #[cfg(feature = "pkcs8")]
-use ed25519::pkcs8::{self, DecodePublicKey};
+use ed25519::pkcs8;
 
 #[cfg(feature = "serde")]
 use serde::de::Error as SerdeError;
@@ -482,9 +482,6 @@ impl TryFrom<&[u8]> for VerifyingKey {
     }
 }
 
-#[cfg(feature = "pkcs8")]
-impl DecodePublicKey for VerifyingKey {}
-
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 impl pkcs8::EncodePublicKey for VerifyingKey {
     fn to_public_key_der(&self) -> pkcs8::spki::Result<pkcs8::Document> {
@@ -525,10 +522,10 @@ impl From<&VerifyingKey> for pkcs8::PublicKeyBytes {
 }
 
 #[cfg(feature = "pkcs8")]
-impl TryFrom<pkcs8::spki::SubjectPublicKeyInfo<'_>> for VerifyingKey {
+impl TryFrom<pkcs8::spki::SubjectPublicKeyInfoRef<'_>> for VerifyingKey {
     type Error = pkcs8::spki::Error;
 
-    fn try_from(public_key: pkcs8::spki::SubjectPublicKeyInfo<'_>) -> pkcs8::spki::Result<Self> {
+    fn try_from(public_key: pkcs8::spki::SubjectPublicKeyInfoRef<'_>) -> pkcs8::spki::Result<Self> {
         pkcs8::PublicKeyBytes::try_from(public_key)?.try_into()
     }
 }


### PR DESCRIPTION
The `ed25519` v2.2.0 crate bumps the `pkcs8` dependency to v0.10.

This updates `ed25519` to the latest version and updates the PKCS#8 support to use the new API.