### PR TITLE
Serde no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = { version = "0.10", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
-serde_bytes = { version = "0.11", optional = true }
+serde_bytes = { version = "0.11", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -46,7 +46,7 @@ criterion = { version = "0.4", features = ["html_reports"] }
 hex-literal = "0.3"
 rand = "0.8"
 rand_core = { version = "0.6.4", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 toml = { version = "0.5" }
 
 [[bench]]
@@ -56,8 +56,8 @@ required-features = ["rand_core"]
 
 [features]
 default = ["fast", "std", "zeroize"]
-alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
-std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
+alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "serde_bytes?/alloc", "zeroize/alloc"]
+std = ["alloc", "ed25519/std", "serde?/std", "serde_bytes?/std", "sha2/std"]
 
 asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
@@ -68,5 +68,5 @@ legacy_compatibility = []
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
-serde = ["dep:serde", "serde_bytes", "ed25519/serde"]
+serde = ["dep:serde", "ed25519/serde", "serde_bytes"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -15,9 +15,9 @@ use ed25519::pkcs8;
 #[cfg(any(test, feature = "rand_core"))]
 use rand_core::CryptoRngCore;
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde::de::Error as SerdeError;
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -19,7 +19,7 @@ use rand_core::CryptoRngCore;
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 
 use sha2::Sha512;
@@ -628,7 +628,7 @@ impl TryFrom<pkcs8::PrivateKeyInfo<'_>> for SigningKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 impl Serialize for SigningKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -638,7 +638,7 @@ impl Serialize for SigningKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 impl<'d> Deserialize<'d> for SigningKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -31,7 +31,7 @@ use ed25519::pkcs8;
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 
 #[cfg(feature = "digest")]
@@ -536,7 +536,7 @@ impl TryFrom<pkcs8::spki::SubjectPublicKeyInfoRef<'_>> for VerifyingKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 impl Serialize for VerifyingKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -546,7 +546,7 @@ impl Serialize for VerifyingKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 impl<'d> Deserialize<'d> for VerifyingKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -27,9 +27,9 @@ use sha2::Sha512;
 #[cfg(feature = "pkcs8")]
 use ed25519::pkcs8;
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde::de::Error as SerdeError;
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(all(feature = "serde", any(feature = "alloc", feature = "std")))]
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -468,14 +468,14 @@ mod integrations {
     }
 }
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(test, feature = "serde", any(feature = "alloc", feature = "std")))]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(crate = "serde")]
 struct Demo {
     signing_key: SigningKey,
 }
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(test, feature = "serde", any(feature = "alloc", feature = "std")))]
 mod serialisation {
     use super::*;
 


### PR DESCRIPTION
This PR addresses issue #287. Tests pass with different combinations of features: "serde", "serde alloc", "serde std", "alloc".