### PR TITLE
Add no_std to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,7 @@ jobs:
           toolchain: stable
           targets: thumbv7em-none-eabi
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "alloc digest rand_core batch zeroize pkcs8"
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "alloc digest rand_core batch zeroize pkcs8 serde"
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,8 @@ jobs:
           targets: thumbv7em-none-eabi
       - uses: taiki-e/install-action@cargo-hack
       # This tests both alloc and no-alloc without std
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features std
+      # TODO: serde pending PR#288
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features std,serde
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
       # No default features build
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
       # TODO: serde pending PR#288
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features std,serde
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,serde
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,8 @@ jobs:
           toolchain: stable
           targets: thumbv7em-none-eabi
       - uses: taiki-e/install-action@cargo-hack
-      # This tests both alloc and no-alloc without std
+      # No default features build
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
       # TODO: serde pending PR#288
       - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features std,serde
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,18 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.60.0
     - run: cargo build
 
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "alloc digest rand_core batch zeroize pkcs8"
+
   bench:
     name: Check that benchmarks compile
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,9 @@ jobs:
         with:
           toolchain: stable
           targets: thumbv7em-none-eabi
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features alloc
-      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "alloc digest rand_core batch zeroize pkcs8 serde"
+      - uses: taiki-e/install-action@cargo-hack
+      # This tests both alloc and no-alloc without std
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features std
 
   bench:
     name: Check that benchmarks compile


### PR DESCRIPTION
The missing test in CI:
- https://github.com/dalek-cryptography/ed25519-dalek/issues/287
- https://github.com/dalek-cryptography/ed25519-dalek/pull/288

Testing that `std` is not required with a target that does not have it by `cargo-hack` excluding `default`, `std` and `serde`

`serde` is excluded and when this test is merged and re-based into #288 it can be tested there with the fix there for `serde`.