### PR TITLE
fix serde / no_std incompatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,8 +82,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       # No default features build
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
-      # TODO: serde pending PR#288
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,serde
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std
 
   bench:
     name: Check that benchmarks compile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,6 @@ dependencies = [
  "rand",
  "rand_core",
  "serde",
- "serde_bytes",
  "serde_json",
  "sha2",
  "signature",
@@ -692,15 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ sha2 = { version = "0.10", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
-serde_bytes = { version = "0.11", optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -68,5 +67,5 @@ legacy_compatibility = []
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
-serde = ["dep:serde", "serde_bytes", "ed25519/serde"]
+serde = ["dep:serde", "ed25519/serde"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]


### PR DESCRIPTION
updates serde `Serialize` and `Deserialize` implementations to use a custom visitor, allowing `serde` to be used without `alloc` or `std` for embedded, and making this consistent with implementations in [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek/blob/a63e14f4ded078d6bf262ba0b3f47026bdd7f7c0/src/edwards.rs#L269).

as an alternative #288 (thanks @semenov-vladyslav)

@pinkforest seems like it'd be good to have some serde tests / this should go over #289?