### PR TITLE
Update to new `Scalar` API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,11 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --features digest,rand_core
       - run: cargo test --target ${{ matrix.target }} --features serde
       - run: cargo test --target ${{ matrix.target }} --features pem
-      - run: cargo test --target ${{ matrix.target }} --all-features
+      # Can't use --all-features because of legacy_compatibility
+      - run: cargo test --target ${{ matrix.target }} --features asm,batch,digest,pem,rand_core,serde
+      - env:
+          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
+        run: cargo test --target ${{ matrix.target }} --features legacy_compatibility
 
   build-simd:
     name: Test simd backend (nightly)
@@ -82,7 +86,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       # No default features build
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,legacy_compatibility
+      - env:
+          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
+        run: cargo build --target thumbv7em-none-eabi --release --features "legacy_compatibility"
 
   bench:
     name: Check that benchmarks compile
@@ -119,4 +126,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - run: cargo doc --all-features
+      - env:
+          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
+        run: cargo doc --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
       - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,legacy_compatibility
       - env:
           RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
-        run: cargo build --target thumbv7em-none-eabi --release --features "legacy_compatibility"
+        run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "legacy_compatibility"
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,11 +39,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --features digest,rand_core
       - run: cargo test --target ${{ matrix.target }} --features serde
       - run: cargo test --target ${{ matrix.target }} --features pem
-      # Can't use --all-features because of legacy_compatibility
-      - run: cargo test --target ${{ matrix.target }} --features asm,batch,digest,pem,rand_core,serde
-      - env:
-          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
-        run: cargo test --target ${{ matrix.target }} --features legacy_compatibility
+        run: cargo test --target ${{ matrix.target }} --all-features
 
   build-simd:
     name: Test simd backend (nightly)
@@ -86,10 +82,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       # No default features build
       - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,legacy_compatibility
-      - env:
-          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
-        run: cargo build --target thumbv7em-none-eabi --release --no-default-features --features "legacy_compatibility"
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --features digest,rand_core
       - run: cargo test --target ${{ matrix.target }} --features serde
       - run: cargo test --target ${{ matrix.target }} --features pem
-        run: cargo test --target ${{ matrix.target }} --all-features
+      - run: cargo test --target ${{ matrix.target }} --all-features
 
   build-simd:
     name: Test simd backend (nightly)
@@ -119,6 +119,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - env:
-          RUSTFLAGS: '-D warnings -A deprecated' # legacy_compatibility triggers a deprecation warning
-        run: cargo doc --all-features
+      - run: cargo doc --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.1"
-source = "git+ssh://git@github.com/rozbb/curve25519-dalek.git?branch=scalar-always-reduced#5d1aae2b391d38c3a3abd7776edbe6499cc1dc8d"
+source = "git+https://github.com/rozbb/curve25519-dalek.git?branch=scalar-always-reduced#5d1aae2b391d38c3a3abd7776edbe6499cc1dc8d"
 dependencies = [
  "cfg-if",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.1"
+source = "git+ssh://git@github.com/rozbb/curve25519-dalek.git?branch=scalar-always-reduced#5d1aae2b391d38c3a3abd7776edbe6499cc1dc8d"
 dependencies = [
  "cfg-if",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.1"
-source = "git+https://github.com/rozbb/curve25519-dalek.git?branch=scalar-always-reduced#5d1aae2b391d38c3a3abd7776edbe6499cc1dc8d"
+version = "4.0.0-rc.2"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?rev=f460ae149b0000695205cc78f560d74a2d3918eb#f460ae149b0000695205cc78f560d74a2d3918eb"
 dependencies = [
  "cfg-if",
  "digest",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-pre.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -313,9 +313,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "generic-array"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,8 +240,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
 dependencies = [
  "cfg-if",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = [
 features = ["batch", "pkcs8"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = ["digest"] }
+curve25519-dalek = { path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -38,7 +38,7 @@ serde_bytes = { version = "0.11", optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = ["digest", "rand_core"] }
+curve25519-dalek = { path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"
@@ -64,7 +64,7 @@ batch = ["alloc", "merlin", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]
 # This features turns off stricter checking for scalar malleability in signatures
-legacy_compatibility = []
+legacy_compatibility = ["curve25519-dalek/legacy_compatibility"]
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]
 # Exposes the hazmat module
 hazmat = []
-# This features turns off stricter checking for scalar malleability in signatures
+# Turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = ["curve25519-dalek/legacy_compatibility"]
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = [
 features = ["batch", "pkcs8"]
 
 [dependencies]
-curve25519-dalek = { path = "../curve25519-dalek", default-features = false, features = ["digest"] }
+curve25519-dalek = { git = "ssh://git@github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -38,7 +38,7 @@ serde_bytes = { version = "0.11", optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
+curve25519-dalek = { git = "ssh://git@github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest", "rand_core"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = [
 features = ["batch", "pkcs8"]
 
 [dependencies]
-curve25519-dalek = { git = "ssh://git@github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest"] }
+curve25519-dalek = { git = "https://github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -38,7 +38,7 @@ serde_bytes = { version = "0.11", optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { git = "ssh://git@github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest", "rand_core"] }
+curve25519-dalek = { git = "https://github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false, features = ["digest", "rand_core"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
 serde = ["dep:serde", "ed25519/serde"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]
+
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/dalek-cryptography/curve25519-dalek.git"
+rev = "f460ae149b0000695205cc78f560d74a2d3918eb"

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -177,7 +177,7 @@ pub fn verify_batch(
             h.update(signatures[i].r_bytes());
             h.update(verifying_keys[i].as_bytes());
             h.update(&messages[i]);
-            h.finalize().try_into().unwrap()
+            *h.finalize().as_ref()
         })
         .collect();
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -98,7 +98,7 @@ impl ExpandedSecretKey {
     /// is not 64.
     pub fn from_slice(bytes: &[u8]) -> Result<Self, SignatureError> {
         // Try to coerce bytes to a [u8; 64]
-        bytes.try_into().map(|b| Self::from_bytes(b)).map_err(|_| {
+        bytes.try_into().map(Self::from_bytes).map_err(|_| {
             InternalError::BytesLength {
                 name: "ExpandedSecretKey",
                 length: 64,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -90,9 +90,11 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
     // as the order of the basepoint is roughly a 2^(252.5) bit number.
     //
     // This succeed-fast trick should succeed for roughly half of all scalars.
+    /*
     if bytes[31] & 240 == 0 {
         return Ok(Scalar::from_bits(bytes));
     }
+    */
 
     match Scalar::from_canonical_bytes(bytes).into() {
         None => Err(InternalError::ScalarFormat.into()),

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -76,6 +76,8 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
         return Err(InternalError::ScalarFormat.into());
     }
 
+    // You cannot do arithmetic with scalars construct with Scalar::from_bits. We only use this
+    // scalar for EdwardsPoint::vartime_double_scalar_mul_basepoint, which is an accepted usecase.
     Ok(Scalar::from_bits(bytes))
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -84,20 +84,6 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
 #[cfg(not(feature = "legacy_compatibility"))]
 #[inline(always)]
 fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
-    // Since this is only used in signature deserialisation (i.e. upon
-    // verification), we can do a "succeed fast" trick by checking that the most
-    // significant 4 bits are unset.  If they are unset, we can succeed fast
-    // because we are guaranteed that the scalar is fully reduced.  However, if
-    // the 4th most significant bit is set, we must do the full reduction check,
-    // as the order of the basepoint is roughly a 2^(252.5) bit number.
-    //
-    // This succeed-fast trick should succeed for roughly half of all scalars.
-    /*
-    if bytes[31] & 240 == 0 {
-        return Ok(Scalar::from_bits(bytes));
-    }
-    */
-
     match Scalar::from_canonical_bytes(bytes).into() {
         None => Err(InternalError::ScalarFormat.into()),
         Some(x) => Ok(x),

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -63,6 +63,10 @@ impl Debug for InternalSignature {
     }
 }
 
+#[deprecated(
+    since = "2.0.0",
+    note = "The legacy_compatibility feature permits signature malleability. See README."
+)]
 #[cfg(feature = "legacy_compatibility")]
 #[inline(always)]
 fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -63,10 +63,9 @@ impl Debug for InternalSignature {
     }
 }
 
-#[deprecated(
-    since = "2.0.0",
-    note = "The legacy_compatibility feature permits signature malleability. See README."
-)]
+/// Ensures that the scalar `s` of a signature is within the bounds [0, 2^253).
+///
+/// **Unsafe**: This version of `check_scalar` permits signature malleability. See README.
 #[cfg(feature = "legacy_compatibility")]
 #[inline(always)]
 fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
@@ -82,10 +81,12 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
 
     // You cannot do arithmetic with scalars construct with Scalar::from_bits. We only use this
     // scalar for EdwardsPoint::vartime_double_scalar_mul_basepoint, which is an accepted usecase.
+    // The `from_bits` method is deprecated because it's unsafe. We know this.
     #[allow(deprecated)]
     Ok(Scalar::from_bits(bytes))
 }
 
+/// Ensures that the scalar `s` of a signature is within the bounds [0, ℓ)
 #[cfg(not(feature = "legacy_compatibility"))]
 #[inline(always)]
 fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -78,6 +78,7 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
 
     // You cannot do arithmetic with scalars construct with Scalar::from_bits. We only use this
     // scalar for EdwardsPoint::vartime_double_scalar_mul_basepoint, which is an accepted usecase.
+    #[allow(deprecated)]
     Ok(Scalar::from_bits(bytes))
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -148,13 +148,17 @@ impl InternalSignature {
     /// only checking the most significant three bits.  (See also the
     /// documentation for [`crate::VerifyingKey::verify_strict`].)
     #[inline]
-    #[allow(clippy::unwrap_used)]
+    #[allow(non_snake_case)]
     pub fn from_bytes(bytes: &[u8; SIGNATURE_LENGTH]) -> Result<InternalSignature, SignatureError> {
         // TODO: Use bytes.split_array_ref once it’s in MSRV.
-        let (lower, upper) = bytes.split_at(32);
+        let mut R_bytes: [u8; 32] = [0u8; 32];
+        let mut s_bytes: [u8; 32] = [0u8; 32];
+        R_bytes.copy_from_slice(&bytes[00..32]);
+        s_bytes.copy_from_slice(&bytes[32..64]);
+
         Ok(InternalSignature {
-            R: CompressedEdwardsY(lower.try_into().unwrap()),
-            s: check_scalar(upper.try_into().unwrap())?,
+            R: CompressedEdwardsY(R_bytes),
+            s: check_scalar(s_bytes)?,
         })
     }
 }

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -20,10 +20,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use sha2::Sha512;
 
-#[cfg(feature = "digest")]
-use curve25519_dalek::digest::generic_array::typenum::U64;
 use curve25519_dalek::{
-    digest::Digest,
+    digest::{generic_array::typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::{clamp_integer, Scalar},
 };

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -462,12 +462,23 @@ impl SigningKey {
         self.verifying_key.verify_strict(message, signature)
     }
 
-    /// Convert this signing key into a Curve25519 scalar.
+    /// Convert this signing key into a byte representation of a(n) (unreduced) Curve25519 scalar.
     ///
-    /// This is useful for e.g. performing X25519 Diffie-Hellman using
-    /// Ed25519 keys.
-    pub fn to_scalar(&self) -> Scalar {
-        ExpandedSecretKey::from(&self.secret_key).scalar
+    /// This can be used for performing X25519 Diffie-Hellman using Ed25519 keys. The bytes output
+    /// by this function are a valid secret key for the X25519 public key given by
+    /// `self.verifying_key().to_montgomery()`.
+    ///
+    /// # Note
+    ///
+    /// We do NOT recommend this usage of a signing/verifying key. Signing keys are usually
+    /// long-term keys, while keys used for key exchange should rather be ephemeral. If you can
+    /// help it, use a separate key for encryption.
+    ///
+    /// For more information on the security of systems which use the same keys for both signing
+    /// and Diffie-Hellman, see the paper
+    /// [On using the same key pair for Ed25519 and an X25519 based KEM](https://eprint.iacr.org/2021/509).
+    pub fn to_scalar_bytes(&self) -> [u8; 32] {
+        ExpandedSecretKey::from(&self.secret_key).scalar_bytes
     }
 }
 
@@ -760,15 +771,14 @@ impl From<&SecretKey> for ExpandedSecretKey {
         // TODO: Use bytes.split_array_ref once it’s in MSRV.
         let (lower, upper) = hash.split_at(32);
 
-        // Clamp the lower bytes. This is the key integer.
-        // The try_into here converts to fixed-size array
-        let key_bytes = clamp_integer(lower.try_into().unwrap());
-        // For signing, we'll need the integer as a Scalar
-        let key = Scalar::from_bytes_mod_order(key_bytes);
+        // The lower bytes are the scalar. The try_into here converts to fixed-size array
+        let scalar_bytes = lower.try_into().unwrap();
+        // For signing, we'll need the integer, clamped, and converted to a Scalar
+        let scalar = Scalar::from_bytes_mod_order(clamp_integer(scalar_bytes));
 
         ExpandedSecretKey {
-            scalar_bytes: key_bytes,
-            scalar: key,
+            scalar_bytes,
+            scalar,
             nonce: upper.try_into().unwrap(),
         }
     }

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -747,7 +747,7 @@ impl<'d> Deserialize<'d> for SigningKey {
 // better-designed, Schnorr-based signature scheme, see Trevor Perrin's work on
 // "generalised EdDSA" and "VXEdDSA".
 pub(crate) struct ExpandedSecretKey {
-    // `key_bytes` and `key` are separate, because the public key is computed as an unreduced
+    // `scalar_bytes` and `scalar` are separate, because the public key is computed as an unreduced
     // scalar multiplication (ie `mul_base_clamped`), whereas the signing operations are done
     // modulo l.
     pub(crate) scalar_bytes: [u8; 32],
@@ -773,7 +773,8 @@ impl From<&SecretKey> for ExpandedSecretKey {
 
         // The lower bytes are the scalar. The try_into here converts to fixed-size array
         let scalar_bytes = lower.try_into().unwrap();
-        // For signing, we'll need the integer, clamped, and converted to a Scalar
+        // For signing, we'll need the integer, clamped, and converted to a Scalar. See
+        // PureEdDSA.keygen in RFC 8032 Appendix A.
         let scalar = Scalar::from_bytes_mod_order(clamp_integer(scalar_bytes));
 
         ExpandedSecretKey {

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -66,7 +66,7 @@ pub struct VerifyingKey {
 }
 
 impl Debug for VerifyingKey {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "VerifyingKey({:?}), {:?})", self.compressed, self.point)
     }
 }
@@ -92,8 +92,7 @@ impl PartialEq<VerifyingKey> for VerifyingKey {
 impl From<&ExpandedSecretKey> for VerifyingKey {
     /// Derive this public key from its corresponding `ExpandedSecretKey`.
     fn from(expanded_secret_key: &ExpandedSecretKey) -> VerifyingKey {
-        let bits: [u8; 32] = expanded_secret_key.key.to_bytes();
-        VerifyingKey::clamp_and_mul_base(bits)
+        VerifyingKey::clamp_and_mul_base(expanded_secret_key.key_bytes)
     }
 }
 
@@ -183,8 +182,7 @@ impl VerifyingKey {
     /// Internal utility function for clamping a scalar representation and multiplying by the
     /// basepont to produce a public key.
     fn clamp_and_mul_base(bits: [u8; 32]) -> VerifyingKey {
-        let scalar = Scalar::from_bits_clamped(bits);
-        let point = EdwardsPoint::mul_base(&scalar);
+        let point = EdwardsPoint::mul_base_clamped(bits);
         let compressed = point.compress();
 
         // Invariant: VerifyingKey.1 is always the decompression of VerifyingKey.0

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -420,15 +420,19 @@ impl VerifyingKey {
 
     /// Convert this verifying key into Montgomery form.
     ///
-    /// This is useful for systems which perform X25519 Diffie-Hellman using
-    /// Ed25519 keys.
+    /// This can be used for performing X25519 Diffie-Hellman using Ed25519 keys. The output of
+    /// this function is a valid X25519 public key whose secret key is `sk.to_scalar_bytes()`,
+    /// where `sk` is a valid signing key for this `VerifyingKey`.
     ///
-    /// When possible, it's recommended to use separate keys for signing and
-    /// Diffie-Hellman.
+    /// # Note
     ///
-    /// For more information on the security of systems which use the same keys
-    /// for both signing and Diffie-Hellman, see the paper
-    /// [On using the same key pair for Ed25519 and an X25519 based KEM](https://eprint.iacr.org/2021/509.pdf).
+    /// We do NOT recommend this usage of a signing/verifying key. Signing keys are usually
+    /// long-term keys, while keys used for key exchange should rather be ephemeral. If you can
+    /// help it, use a separate key for encryption.
+    ///
+    /// For more information on the security of systems which use the same keys for both signing
+    /// and Diffie-Hellman, see the paper
+    /// [On using the same key pair for Ed25519 and an X25519 based KEM](https://eprint.iacr.org/2021/509).
     pub fn to_montgomery(&self) -> MontgomeryPoint {
         self.point.to_montgomery()
     }

--- a/tests/x25519.rs
+++ b/tests/x25519.rs
@@ -16,16 +16,16 @@ fn ed25519_to_x25519_dh() {
     let ed25519_signing_key_a = SigningKey::from_bytes(&ed25519_secret_key_a);
     let ed25519_signing_key_b = SigningKey::from_bytes(&ed25519_secret_key_b);
 
-    let scalar_a = ed25519_signing_key_a.to_scalar();
-    let scalar_b = ed25519_signing_key_b.to_scalar();
+    let scalar_a = ed25519_signing_key_a.to_scalar_bytes();
+    let scalar_b = ed25519_signing_key_b.to_scalar_bytes();
 
     assert_eq!(
-        scalar_a.to_bytes(),
-        hex!("307c83864f2833cb427a2ef1c00a013cfdff2768d980c0a3a520f006904de94f")
+        scalar_a,
+        hex!("357c83864f2833cb427a2ef1c00a013cfdff2768d980c0a3a520f006904de90f")
     );
     assert_eq!(
-        scalar_b.to_bytes(),
-        hex!("68bd9ed75882d52815a97585caf4790a7f6c6b3b7f821c5e259a24b02e502e51")
+        scalar_b,
+        hex!("6ebd9ed75882d52815a97585caf4790a7f6c6b3b7f821c5e259a24b02e502e11")
     );
 
     let x25519_public_key_a = ed25519_signing_key_a.verifying_key().to_montgomery();
@@ -44,11 +44,11 @@ fn ed25519_to_x25519_dh() {
         hex!("5166f24a6918368e2af831a4affadd97af0ac326bdf143596c045967cc00230e");
 
     assert_eq!(
-        (x25519_public_key_a * scalar_b).to_bytes(),
+        x25519_public_key_a.mul_clamped(scalar_b).to_bytes(),
         expected_shared_secret
     );
     assert_eq!(
-        (x25519_public_key_b * scalar_a).to_bytes(),
+        x25519_public_key_b.mul_clamped(scalar_a).to_bytes(),
         expected_shared_secret
     );
 }

--- a/tests/x25519.rs
+++ b/tests/x25519.rs
@@ -16,15 +16,15 @@ fn ed25519_to_x25519_dh() {
     let ed25519_signing_key_a = SigningKey::from_bytes(&ed25519_secret_key_a);
     let ed25519_signing_key_b = SigningKey::from_bytes(&ed25519_secret_key_b);
 
-    let scalar_a = ed25519_signing_key_a.to_scalar_bytes();
-    let scalar_b = ed25519_signing_key_b.to_scalar_bytes();
+    let scalar_a_bytes = ed25519_signing_key_a.to_scalar_bytes();
+    let scalar_b_bytes = ed25519_signing_key_b.to_scalar_bytes();
 
     assert_eq!(
-        scalar_a,
+        scalar_a_bytes,
         hex!("357c83864f2833cb427a2ef1c00a013cfdff2768d980c0a3a520f006904de90f")
     );
     assert_eq!(
-        scalar_b,
+        scalar_b_bytes,
         hex!("6ebd9ed75882d52815a97585caf4790a7f6c6b3b7f821c5e259a24b02e502e11")
     );
 
@@ -44,11 +44,11 @@ fn ed25519_to_x25519_dh() {
         hex!("5166f24a6918368e2af831a4affadd97af0ac326bdf143596c045967cc00230e");
 
     assert_eq!(
-        x25519_public_key_a.mul_clamped(scalar_b).to_bytes(),
+        x25519_public_key_a.mul_clamped(scalar_b_bytes).to_bytes(),
         expected_shared_secret
     );
     assert_eq!(
-        x25519_public_key_b.mul_clamped(scalar_a).to_bytes(),
+        x25519_public_key_b.mul_clamped(scalar_a_bytes).to_bytes(),
         expected_shared_secret
     );
 }


### PR DESCRIPTION
This removes all uses of `Scalar::{from_bits, from_bits_clamped}`. Some comments inline.

`curve25519-dalek` dependency is pinned to Git in `Cargo.toml`, with revision `f460ae1` specified in `Cargo.lock`. I'll move this back to a semver dep once a new `curve25519-dalek` RC is cut.