### PR TITLE
chore: Release 2.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Bump MSRV from 1.41 to 1.60.0
 * Bump Rust edition
 * Bump `signature` dependency to 2.0
-* Make [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) more automatic
 * Make `digest` an optional dependency
 * Make `zeroize` an optional dependency
 * Make `rand_core` an optional dependency
+* Adopt [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) over features
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Impl `Hash` for `VerifyingKey`
 * Impl `Clone`, `Drop`, and `ZeroizeOnDrop` for `SigningKey`
 * Remove `rand` dependency
+* Improve key deserialization diagnostics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "2.0.0-pre.0"
+version = "2.0.0-rc.2"
 edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
@@ -25,7 +25,7 @@ rustdoc-args = [
 features = ["batch", "pkcs8"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = ["digest"] }
+curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -37,7 +37,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features = ["digest", "rand_core"] }
+curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = ["digest", "rand_core"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of t
 * Bump MSRV from 1.41 to 1.60.0
 * Bump Rust edition
 * Bump `signature` dependency to 2.0
-* Make [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) more automatic
 * Make `digest` an optional dependency
 * Make `zeroize` an optional dependency
 * Make `rand_core` an optional dependency
+* Adopt [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) over features
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ed25519-dalek = "1"
 To use the latest prerelease (see changes [below](#breaking-changes-in-200)),
 use the following line in your project's `Cargo.toml`:
 ```toml
-ed25519-dalek = "2.0.0-rc.0"
+ed25519-dalek = "2.0.0-rc.2"
 ```
 
 # Feature Flags

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ed25519-dalek = "1"
 To use the latest prerelease (see changes [below](#breaking-changes-in-200)),
 use the following line in your project's `Cargo.toml`:
 ```toml
-ed25519-dalek = "2.0.0-pre.0"
+ed25519-dalek = "2.0.0-rc.0"
 ```
 
 # Feature Flags


### PR DESCRIPTION
Fixes #274 
Aligns curve25519-dalek 4.0.0 rc.2: https://github.com/dalek-cryptography/curve25519-dalek/pull/522

- Manifest rc.2
- Bump README
- Bump CHANGELOG

Tests fail atm because curve25519 crates.io is pending rc.2 release.