### PR TITLE
Add `hazmat` module with `ExpandedSecretKey`, `raw_sign`, `raw_sign_prehashed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
+* Make `raw_sign` feature to expose `raw_sign()` and `raw_sign_prehashed()` functions
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
-* Make `raw_sign` feature to expose `raw_sign()` and `raw_sign_prehashed()` functions
+* Make `hazmat` feature to expose, `ExpandedSecretKey`, `raw_sign()`, `raw_sign_prehashed()`, `raw_verify()`, and `raw_verify_prehashed()`
 
 ### Other changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -290,6 +300,7 @@ name = "ed25519-dalek"
 version = "2.0.0-rc.2"
 dependencies = [
  "bincode",
+ "blake2",
  "criterion",
  "curve25519-dalek",
  "ed25519",
@@ -301,6 +312,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sha3",
  "signature",
  "toml",
  "zeroize",
@@ -734,6 +746,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = [
     "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
     "--cfg", "docsrs",
 ]
-features = ["batch", "pkcs8"]
+features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = ["digest"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,12 +62,12 @@ asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]
+# Exposes the hazmat module
+hazmat = []
 # Turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
-# Exposes the unsafe raw_sign() and raw_sign_prehashed() functions
-raw_sign = []
 serde = ["dep:serde", "ed25519/serde"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
 curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = ["digest", "rand_core"] }
+blake2 = "0.10"
+sha3 = "0.10"
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,12 @@ asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]
-# This features turns off stricter checking for scalar malleability in signatures
+# Turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
 pkcs8 = ["ed25519/pkcs8"]
 pem = ["alloc", "ed25519/pem", "pkcs8"]
 rand_core = ["dep:rand_core"]
+# Exposes the unsafe raw_sign() and raw_sign_prehashed() functions
+raw_sign = []
 serde = ["dep:serde", "ed25519/serde"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
 | `pem`                  |          | Enables PEM serialization support for PKCS#8 private keys and SPKI public keys. Also enables `alloc`. |
 | `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |
+| `raw_sign` |          | **Unsafe:** Exposes the `raw_sign()` and (if `digest` is set) `raw_sign_prehashed()` methods. Misuse of these functions will expose the private key, as in the [signing oracle attack](https://github.com/MystenLabs/ed25519-unsafe-libs). |
 
 # Major Changes
 
@@ -54,6 +55,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of t
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
+* Make `raw_sign` feature to expose `raw_sign()` and `raw_sign_prehashed()` functions
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
 | `pem`                  |          | Enables PEM serialization support for PKCS#8 private keys and SPKI public keys. Also enables `alloc`. |
 | `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |
-| `raw_sign` |          | **Unsafe:** Exposes the `raw_sign()` and (if `digest` is set) `raw_sign_prehashed()` methods. Misuse of these functions will expose the private key, as in the [signing oracle attack](https://github.com/MystenLabs/ed25519-unsafe-libs). |
+| `hazmat` |          | **Unsafe:** Exposes the `hazmat` module for raw signing/verifying. Misuse of these functions will expose the private key, as in the [signing oracle attack](https://github.com/MystenLabs/ed25519-unsafe-libs). |
 
 # Major Changes
 
@@ -55,7 +55,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of t
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
 * Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
-* Make `raw_sign` feature to expose `raw_sign()` and `raw_sign_prehashed()` functions
+* Make `hazmat` feature to expose, `ExpandedSecretKey`, `raw_sign()`, `raw_sign_prehashed()`, `raw_verify()`, and `raw_verify_prehashed()`
 
 # Documentation
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -66,6 +66,7 @@ impl ExpandedSecretKey {
 
     /// Construct an `ExpandedSecretKey` from an array of 64 bytes.
     pub fn from_bytes(bytes: &[u8; 64]) -> Self {
+        // TODO: Use bytes.split_array_ref once it’s in MSRV.
         let mut lower: [u8; 32] = [0u8; 32];
         let mut upper: [u8; 32] = [0u8; 32];
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -13,7 +13,7 @@
 // defined.
 #![allow(dead_code)]
 
-use crate::{InternalError, SignatureError};
+use crate::SignatureError;
 
 use curve25519_dalek::Scalar;
 
@@ -64,30 +64,18 @@ impl ExpandedSecretKey {
         bytes
     }
 
-    /// Construct an `ExpandedSecretKey` from a slice of bytes.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` whose okay value is an EdDSA `ExpandedSecretKey` or whose error value is an
-    /// `SignatureError` describing the error that occurred.
-    pub fn from_bytes(bytes: &[u8]) -> Result<ExpandedSecretKey, SignatureError> {
-        if bytes.len() != 64 {
-            return Err(InternalError::BytesLength {
-                name: "ExpandedSecretKey",
-                length: 64,
-            }
-            .into());
-        }
+    /// Construct an `ExpandedSecretKey` from an array of 64 bytes.
+    pub fn from_bytes(bytes: &[u8; 64]) -> Self {
         let mut lower: [u8; 32] = [0u8; 32];
         let mut upper: [u8; 32] = [0u8; 32];
 
         lower.copy_from_slice(&bytes[00..32]);
         upper.copy_from_slice(&bytes[32..64]);
 
-        Ok(ExpandedSecretKey {
+        ExpandedSecretKey {
             scalar: Scalar::from_bytes_mod_order(lower),
             hash_prefix: upper,
-        })
+        }
     }
 }
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -15,7 +15,8 @@ use crate::{signing::private_raw_sign, InternalError, Signature, SignatureError,
 #[cfg(feature = "digest")]
 use curve25519_dalek::digest::{generic_array::typenum::U64, Digest};
 use curve25519_dalek::Scalar;
-use zeroize::Zeroize;
+#[cfg(feature = "zeroize")]
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Contains the secret scalar and domain separator used for generating signatures.
 ///
@@ -32,12 +33,16 @@ pub struct ExpandedSecretKey {
     pub hash_prefix: [u8; 32],
 }
 
+#[cfg(feature = "zeroize")]
 impl Drop for ExpandedSecretKey {
     fn drop(&mut self) {
         self.scalar.zeroize();
         self.hash_prefix.zeroize()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl ZeroizeOnDrop for ExpandedSecretKey {}
 
 impl ExpandedSecretKey {
     /// Convert this `ExpandedSecretKey` into an array of 64 bytes.

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -88,7 +88,7 @@ impl ExpandedSecretKey {
     }
 }
 
-/// Compute an ordinary Ed25519 signature over the given message. `SigDigest` is the digest used to
+/// Compute an ordinary Ed25519 signature over the given message. `CtxDigest` is the digest used to
 /// calculate the pseudorandomness needed for signing. This is SHA-512 in Ed25519.
 ///
 /// # ⚠️  Unsafe
@@ -97,20 +97,20 @@ impl ExpandedSecretKey {
 /// `ExpandedSecretKey` can leak your signing key. See
 /// [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on this attack.
 #[cfg(feature = "hazmat")]
-pub fn raw_sign<SigDigest>(
+pub fn raw_sign<CtxDigest>(
     esk: ExpandedSecretKey,
     message: &[u8],
     verifying_key: &VerifyingKey,
 ) -> Signature
 where
-    SigDigest: Digest<OutputSize = U64>,
+    CtxDigest: Digest<OutputSize = U64>,
 {
-    esk.raw_sign::<SigDigest>(message, verifying_key)
+    esk.raw_sign::<CtxDigest>(message, verifying_key)
 }
 
 /// Compute a signature over the given prehashed message, the Ed25519ph algorithm defined in
 /// [RFC8032 §5.1][rfc8032]. `MsgDigest` is the digest function used to hash the signed message.
-/// `SigDigest` is the digest function used to calculate the pseudorandomness needed for signing.
+/// `CtxDigest` is the digest function used to calculate the pseudorandomness needed for signing.
 /// These are both SHA-512 in Ed25519.
 ///
 /// # ⚠️  Unsafe
@@ -142,7 +142,7 @@ where
 /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
 #[cfg(all(feature = "hazmat", feature = "digest"))]
 #[allow(non_snake_case)]
-pub fn raw_sign_prehashed<'a, MsgDigest, SigDigest>(
+pub fn raw_sign_prehashed<'a, MsgDigest, CtxDigest>(
     esk: ExpandedSecretKey,
     prehashed_message: MsgDigest,
     verifying_key: &VerifyingKey,
@@ -150,7 +150,7 @@ pub fn raw_sign_prehashed<'a, MsgDigest, SigDigest>(
 ) -> Result<Signature, SignatureError>
 where
     MsgDigest: Digest<OutputSize = U64>,
-    SigDigest: Digest<OutputSize = U64>,
+    CtxDigest: Digest<OutputSize = U64>,
 {
-    esk.raw_sign_prehashed::<MsgDigest, SigDigest>(prehashed_message, verifying_key, context)
+    esk.raw_sign_prehashed::<MsgDigest, CtxDigest>(prehashed_message, verifying_key, context)
 }

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -8,15 +8,13 @@
 //! Failure to use them correctly can lead to catastrophic failures including **full private key
 //! recovery.**
 
-use crate::{
-    signing::{private_raw_sign, private_raw_sign_prehashed},
-    InternalError, Signature, SignatureError, VerifyingKey,
-};
+#[cfg(feature = "digest")]
+use crate::signing::private_raw_sign_prehashed;
+use crate::{signing::private_raw_sign, InternalError, Signature, SignatureError, VerifyingKey};
 
-use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
-    Scalar,
-};
+#[cfg(feature = "digest")]
+use curve25519_dalek::digest::{generic_array::typenum::U64, Digest};
+use curve25519_dalek::Scalar;
 use zeroize::Zeroize;
 
 /// Contains the secret scalar and domain separator used for generating signatures.

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -81,7 +81,8 @@ impl ExpandedSecretKey {
 }
 
 /// Compute an ordinary Ed25519 signature over the given message. `CtxDigest` is the digest used to
-/// calculate the pseudorandomness needed for signing. This is SHA-512 in Ed25519.
+/// calculate the pseudorandomness needed for signing. According to the Ed25519 spec, `CtxDigest =
+/// Sha512`.
 ///
 /// # ⚠️  Unsafe
 ///
@@ -102,7 +103,7 @@ where
 /// Compute a signature over the given prehashed message, the Ed25519ph algorithm defined in
 /// [RFC8032 §5.1][rfc8032]. `MsgDigest` is the digest function used to hash the signed message.
 /// `CtxDigest` is the digest function used to calculate the pseudorandomness needed for signing.
-/// These are both SHA-512 in Ed25519.
+/// According to the Ed25519 spec, `MsgDigest = CtxDigest = Sha512`.
 ///
 /// # ⚠️  Unsafe
 //
@@ -112,7 +113,7 @@ where
 ///
 /// # Inputs
 ///
-/// * `sk` is the [`ExpandedSecretKey`] being used for signing
+/// * `esk` is the [`ExpandedSecretKey`] being used for signing
 /// * `prehashed_message` is an instantiated hash digest with 512-bits of
 ///   output which has had the message to be signed previously fed into its
 ///   state.
@@ -148,7 +149,7 @@ where
 
 /// The ordinary non-batched Ed25519 verification check, rejecting non-canonical R
 /// values.`CtxDigest` is the digest used to calculate the pseudorandomness needed for signing.
-/// According to the spec, `CtxDigest = Sha512`.
+/// According to the Ed25519 spec, `CtxDigest = Sha512`.
 pub fn raw_verify<CtxDigest>(
     vk: &VerifyingKey,
     message: &[u8],
@@ -162,7 +163,8 @@ where
 
 /// The batched Ed25519 verification check, rejecting non-canonical R values. `MsgDigest` is the
 /// digest used to hash the signed message. `CtxDigest` is the digest used to calculate the
-/// pseudorandomness needed for signing. According to the spec, `MsgDgiest = CtxDigest = Sha512`.
+/// pseudorandomness needed for signing. According to the Ed25519 spec, `MsgDigest = CtxDigest =
+/// Sha512`.
 #[cfg(feature = "digest")]
 #[allow(non_snake_case)]
 pub fn raw_verify_prehashed<CtxDigest, MsgDigest>(

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -13,7 +13,7 @@
 // defined.
 #![allow(dead_code)]
 
-use crate::SignatureError;
+use crate::{InternalError, SignatureError};
 
 use curve25519_dalek::Scalar;
 
@@ -77,6 +77,33 @@ impl ExpandedSecretKey {
             scalar: Scalar::from_bytes_mod_order(lower),
             hash_prefix: upper,
         }
+    }
+
+    /// Construct an `ExpandedSecretKey` from a slice of 64 bytes.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` whose okay value is an EdDSA `ExpandedSecretKey` or whose error value is an
+    /// `SignatureError` describing the error that occurred, namely that the given slice's length
+    /// is not 64.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, SignatureError> {
+        if bytes.len() != 64 {
+            return Err(InternalError::BytesLength {
+                name: "ExpandedSecretKey",
+                length: 64,
+            }
+            .into());
+        } else {
+            Ok(Self::from_bytes(bytes.try_into().unwrap()))
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for ExpandedSecretKey {
+    type Error = SignatureError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_slice(bytes)
     }
 }
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,0 +1,97 @@
+//! Low-level interfaces to ed25519 functions
+//!
+//! # ⚠️ Warning: Hazmat
+//!
+//! These primitives are easy-to-misuse low-level interfaces.
+//!
+//! If you are an end user / non-expert in cryptography, **do not use any of these functions**.
+//! Failure to use them correctly can lead to catastrophic failures including **full private key
+//! recovery.**
+
+use crate::{
+    signing::{private_raw_sign, private_raw_sign_prehashed},
+    Signature, SignatureError, VerifyingKey,
+};
+
+use curve25519_dalek::{
+    digest::{generic_array::typenum::U64, Digest},
+    Scalar,
+};
+
+/// Computes an ordinary Ed25519 signature over the given message.
+///
+/// # ⚠️  Unsafe
+///
+/// Do NOT use this function unless you absolutely must. Misuse of this function can expose your
+/// private key. See [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on
+/// this attack.
+///
+/// # Inputs
+///
+/// * `scalar` is the secret scalar of the signing key
+/// * `hash_prefix` is the domain separator that, along with the message itself, is used to
+///   deterministically generate the `R` part of the signature.
+///
+/// `scalar` and `hash_prefix` are usually selected such that `scalar || hash_prefix = H(sk)` where
+/// `sk` is the signing key
+pub fn raw_sign(
+    scalar: Scalar,
+    hash_prefix: [u8; 32],
+    message: &[u8],
+    verifying_key: &VerifyingKey,
+) -> Signature {
+    private_raw_sign(scalar, hash_prefix, message, verifying_key)
+}
+
+/// Computes a signature over the given prehashed message, the Ed25519ph algorithm defined in
+/// [RFC8032 §5.1][rfc8032].
+///
+/// # ⚠️  Unsafe
+//
+/// Do NOT use this function unless you absolutely must. Misuse of this function can expose your
+/// private key. See [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on
+/// this attack.
+///
+/// # Inputs
+///
+/// * `scalar` is the secret scalar of the signing key
+/// * `hash_prefix` is the domain separator that, along with the prehashed message, is used to
+///   deterministically generate the `R` part of the signature.
+/// * `prehashed_message` is an instantiated hash digest with 512-bits of
+///   output which has had the message to be signed previously fed into its
+///   state.
+/// * `verifying_key` is a [`VerifyingKey`] which corresponds to this secret key.
+/// * `context` is an optional context string, up to 255 bytes inclusive,
+///   which may be used to provide additional domain separation.  If not
+///   set, this will default to an empty string.
+///
+/// `scalar` and `hash_prefix` are usually selected such that `scalar || hash_prefix = H(sk)` where
+/// `sk` is the signing key
+///
+/// # Returns
+///
+/// A `Result` whose `Ok` value is an Ed25519ph [`Signature`] on the
+/// `prehashed_message` if the context was 255 bytes or less, otherwise
+/// a `SignatureError`.
+///
+/// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
+#[cfg(feature = "digest")]
+#[allow(non_snake_case)]
+pub fn raw_sign_prehashed<'a, D>(
+    scalar: Scalar,
+    hash_prefix: [u8; 32],
+    prehashed_message: D,
+    verifying_key: &VerifyingKey,
+    context: Option<&'a [u8]>,
+) -> Result<Signature, SignatureError>
+where
+    D: Digest<OutputSize = U64>,
+{
+    private_raw_sign_prehashed(
+        scalar,
+        hash_prefix,
+        prehashed_message,
+        verifying_key,
+        context,
+    )
+}

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -86,14 +86,16 @@ impl ExpandedSecretKey {
     /// A `Result` whose okay value is an EdDSA `ExpandedSecretKey` or whose error value is an
     /// `SignatureError` describing the error that occurred, namely that the given slice's length
     /// is not 64.
+    #[allow(clippy::unwrap_used)]
     pub fn from_slice(bytes: &[u8]) -> Result<Self, SignatureError> {
         if bytes.len() != 64 {
-            return Err(InternalError::BytesLength {
+            Err(InternalError::BytesLength {
                 name: "ExpandedSecretKey",
                 length: 64,
             }
-            .into());
+            .into())
         } else {
+            // If the input is 64 bytes long, coerce it to a 64-byte array
             Ok(Self::from_bytes(bytes.try_into().unwrap()))
         }
     }

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -21,9 +21,7 @@ use curve25519_dalek::Scalar;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // These are used in the functions that are made public when the hazmat feature is set
-#[cfg(feature = "hazmat")]
 use crate::{Signature, VerifyingKey};
-#[cfg(feature = "hazmat")]
 use curve25519_dalek::digest::{generic_array::typenum::U64, Digest};
 
 /// Contains the secret scalar and domain separator used for generating signatures.
@@ -178,7 +176,7 @@ where
 /// pseudorandomness needed for signing. According to the spec, `MsgDgiest = CtxDigest = Sha512`.
 #[cfg(feature = "digest")]
 #[allow(non_snake_case)]
-pub(crate) fn raw_verify_prehashed<CtxDigest, MsgDigest>(
+pub fn raw_verify_prehashed<CtxDigest, MsgDigest>(
     vk: &VerifyingKey,
     prehashed_message: MsgDigest,
     context: Option<&[u8]>,
@@ -195,7 +193,7 @@ where
 mod test {
     use super::*;
 
-    use curve25519_dalek::{digest::Digest, Scalar};
+    use curve25519_dalek::Scalar;
     use rand::{rngs::OsRng, CryptoRng, RngCore};
 
     // Pick distinct, non-spec 512-bit hash functions for message and sig-context hashing
@@ -237,8 +235,11 @@ mod test {
 
     // Check that raw_sign_prehashed and raw_verify_prehashed work when distinct, non-spec
     // MsgDigest and CtxDigest are used
+    #[cfg(feature = "digest")]
     #[test]
     fn sign_verify_prehashed_nonspec() {
+        use cureve25519_dalek::digest::Digest;
+
         // Generate the keypair
         let mut rng = OsRng;
         let esk = ExpandedSecretKey::random(&mut rng);

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -238,7 +238,7 @@ mod test {
     #[cfg(feature = "digest")]
     #[test]
     fn sign_verify_prehashed_nonspec() {
-        use cureve25519_dalek::digest::Digest;
+        use curve25519_dalek::digest::Digest;
 
         // Generate the keypair
         let mut rng = OsRng;

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -10,53 +10,97 @@
 
 use crate::{
     signing::{private_raw_sign, private_raw_sign_prehashed},
-    Signature, SignatureError, VerifyingKey,
+    InternalError, Signature, SignatureError, VerifyingKey,
 };
 
 use curve25519_dalek::{
     digest::{generic_array::typenum::U64, Digest},
     Scalar,
 };
+use zeroize::Zeroize;
 
-/// Computes an ordinary Ed25519 signature over the given message.
+/// Contains the secret scalar and domain separator used for generating signatures.
+///
+/// In the usual Ed25519 signing algorithm, `scalar` and `hash_prefix` are defined such that
+/// `scalar || hash_prefix = H(sk)` where `sk` is the signing key and `H` is SHA-512.
+/// **WARNING:** Deriving the values for these fields in any other way can lead to full key
+/// recovery, as documented in [`raw_sign`] and [`raw_sign_prehashed`].
+///
+/// Instances of this secret are automatically overwritten with zeroes when they fall out of scope.
+pub struct ExpandedSecretKey {
+    /// The secret scalar used for signing
+    pub scalar: Scalar,
+    /// The domain separator used when hashing the message to generate the pseudorandom `r` value
+    pub hash_prefix: [u8; 32],
+}
+
+impl Drop for ExpandedSecretKey {
+    fn drop(&mut self) {
+        self.scalar.zeroize();
+        self.hash_prefix.zeroize()
+    }
+}
+
+impl ExpandedSecretKey {
+    /// Convert this `ExpandedSecretKey` into an array of 64 bytes.
+    pub fn to_bytes(&self) -> [u8; 64] {
+        let mut bytes: [u8; 64] = [0u8; 64];
+
+        bytes[..32].copy_from_slice(self.scalar.as_bytes());
+        bytes[32..].copy_from_slice(&self.hash_prefix[..]);
+        bytes
+    }
+
+    /// Construct an `ExpandedSecretKey` from a slice of bytes.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` whose okay value is an EdDSA `ExpandedSecretKey` or whose error value is an
+    /// `SignatureError` describing the error that occurred.
+    pub fn from_bytes(bytes: &[u8]) -> Result<ExpandedSecretKey, SignatureError> {
+        if bytes.len() != 64 {
+            return Err(InternalError::BytesLength {
+                name: "ExpandedSecretKey",
+                length: 64,
+            }
+            .into());
+        }
+        let mut lower: [u8; 32] = [0u8; 32];
+        let mut upper: [u8; 32] = [0u8; 32];
+
+        lower.copy_from_slice(&bytes[00..32]);
+        upper.copy_from_slice(&bytes[32..64]);
+
+        Ok(ExpandedSecretKey {
+            scalar: Scalar::from_bytes_mod_order(lower),
+            hash_prefix: upper,
+        })
+    }
+}
+
+/// Compute an ordinary Ed25519 signature over the given message.
 ///
 /// # ⚠️  Unsafe
 ///
-/// Do NOT use this function unless you absolutely must. Misuse of this function can expose your
-/// private key. See [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on
-/// this attack.
-///
-/// # Inputs
-///
-/// * `scalar` is the secret scalar of the signing key
-/// * `hash_prefix` is the domain separator that, along with the message itself, is used to
-///   deterministically generate the `R` part of the signature.
-///
-/// `scalar` and `hash_prefix` are usually selected such that `scalar || hash_prefix = H(sk)` where
-/// `sk` is the signing key
-pub fn raw_sign(
-    scalar: Scalar,
-    hash_prefix: [u8; 32],
-    message: &[u8],
-    verifying_key: &VerifyingKey,
-) -> Signature {
-    private_raw_sign(scalar, hash_prefix, message, verifying_key)
+/// Do NOT use this function unless you absolutely must. Using the wrong values in
+/// `ExpandedSecretKey` can leak your signing key. See
+/// [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on this attack.
+pub fn raw_sign(sk: ExpandedSecretKey, message: &[u8], verifying_key: &VerifyingKey) -> Signature {
+    private_raw_sign(sk.scalar, sk.hash_prefix, message, verifying_key)
 }
 
-/// Computes a signature over the given prehashed message, the Ed25519ph algorithm defined in
+/// Compute a signature over the given prehashed message, the Ed25519ph algorithm defined in
 /// [RFC8032 §5.1][rfc8032].
 ///
 /// # ⚠️  Unsafe
 //
-/// Do NOT use this function unless you absolutely must. Misuse of this function can expose your
-/// private key. See [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on
-/// this attack.
+/// Do NOT use this function unless you absolutely must. Using the wrong values in
+/// `ExpandedSecretKey` can leak your signing key. See
+/// [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on this attack.
 ///
 /// # Inputs
 ///
-/// * `scalar` is the secret scalar of the signing key
-/// * `hash_prefix` is the domain separator that, along with the prehashed message, is used to
-///   deterministically generate the `R` part of the signature.
+/// * `sk` is the [`ExpandedSecretKey`] being used for signing
 /// * `prehashed_message` is an instantiated hash digest with 512-bits of
 ///   output which has had the message to be signed previously fed into its
 ///   state.
@@ -78,8 +122,7 @@ pub fn raw_sign(
 #[cfg(feature = "digest")]
 #[allow(non_snake_case)]
 pub fn raw_sign_prehashed<'a, D>(
-    scalar: Scalar,
-    hash_prefix: [u8; 32],
+    sk: ExpandedSecretKey,
     prehashed_message: D,
     verifying_key: &VerifyingKey,
     context: Option<&'a [u8]>,
@@ -88,8 +131,8 @@ where
     D: Digest<OutputSize = U64>,
 {
     private_raw_sign_prehashed(
-        scalar,
-        hash_prefix,
+        sk.scalar,
+        sk.hash_prefix,
         prehashed_message,
         verifying_key,
         context,

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -172,3 +172,21 @@ where
 {
     vk.raw_verify::<CtxDigest>(message, signature)
 }
+
+/// The batched Ed25519 verification check, rejecting non-canonical R values. `MsgDigest` is the
+/// digest used to hash the signed message. `CtxDigest` is the digest used to calculate the
+/// pseudorandomness needed for signing. According to the spec, `MsgDgiest = CtxDigest = Sha512`.
+#[cfg(feature = "digest")]
+#[allow(non_snake_case)]
+pub(crate) fn raw_verify_prehashed<MsgDigest, CtxDigest>(
+    vk: &VerifyingKey,
+    prehashed_message: MsgDigest,
+    context: Option<&[u8]>,
+    signature: &ed25519::Signature,
+) -> Result<(), SignatureError>
+where
+    MsgDigest: Digest<OutputSize = U64>,
+    CtxDigest: Digest<OutputSize = U64>,
+{
+    vk.raw_verify_prehashed::<MsgDigest, CtxDigest>(prehashed_message, context, signature)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,8 @@ mod verifying;
 
 #[cfg(feature = "hazmat")]
 pub mod hazmat;
+#[cfg(not(feature = "hazmat"))]
+mod hazmat;
 
 #[cfg(feature = "digest")]
 pub use curve25519_dalek::digest::Digest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,9 @@ mod signature;
 mod signing;
 mod verifying;
 
+#[cfg(feature = "hazmat")]
+pub mod hazmat;
+
 #[cfg(feature = "digest")]
 pub use curve25519_dalek::digest::Digest;
 #[cfg(feature = "digest")]

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -309,7 +309,7 @@ impl SigningKey {
     where
         MsgDigest: Digest<OutputSize = U64>,
     {
-        ExpandedSecretKey::from(&self.secret_key).raw_sign_prehashed::<MsgDigest, Sha512>(
+        ExpandedSecretKey::from(&self.secret_key).raw_sign_prehashed::<Sha512, MsgDigest>(
             prehashed_message,
             &self.verifying_key,
             context,
@@ -767,9 +767,9 @@ impl ExpandedSecretKey {
         InternalSignature { R, s }.into()
     }
 
-    /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `MsgDigest` is the digest
-    /// function used to hash the signed message. `CtxDigest` is the digest function used to
-    /// calculate the pseudorandomness needed for signing. According to the spec, `MsgDigest =
+    /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `CtxDigest` is the digest
+    /// function used to calculate the pseudorandomness needed for signing. `MsgDigest` is the
+    /// digest function used to hash the signed message. According to the spec, `MsgDigest =
     /// CtxDigest = Sha512`, and `self` is derived via the method defined in `impl
     /// From<&SigningKey> for ExpandedSecretKey`.
     ///
@@ -778,15 +778,15 @@ impl ExpandedSecretKey {
     #[cfg(feature = "digest")]
     #[allow(non_snake_case)]
     #[inline(always)]
-    pub(crate) fn raw_sign_prehashed<'a, MsgDigest, CtxDigest>(
+    pub(crate) fn raw_sign_prehashed<'a, CtxDigest, MsgDigest>(
         &self,
         prehashed_message: MsgDigest,
         verifying_key: &VerifyingKey,
         context: Option<&'a [u8]>,
     ) -> Result<Signature, SignatureError>
     where
-        MsgDigest: Digest<OutputSize = U64>,
         CtxDigest: Digest<OutputSize = U64>,
+        MsgDigest: Digest<OutputSize = U64>,
     {
         let mut prehash: [u8; 64] = [0u8; 64];
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -20,12 +20,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use sha2::Sha512;
 
-#[cfg(feature = "digest")]
-use curve25519_dalek::digest::generic_array::typenum::U64;
-use curve25519_dalek::digest::Digest;
-use curve25519_dalek::edwards::CompressedEdwardsY;
-use curve25519_dalek::edwards::EdwardsPoint;
-use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::{
+    digest::{generic_array::typenum::U64, Digest},
+    edwards::{CompressedEdwardsY, EdwardsPoint},
+    scalar::Scalar,
+};
 
 use ed25519::signature::{KeypairRef, Signer, Verifier};
 
@@ -37,11 +36,14 @@ use signature::DigestSigner;
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::constants::*;
-use crate::errors::*;
-use crate::signature::*;
-use crate::verifying::*;
-use crate::Signature;
+use crate::{
+    constants::{KEYPAIR_LENGTH, SECRET_KEY_LENGTH},
+    errors::{InternalError, SignatureError},
+    hazmat::ExpandedSecretKey,
+    signature::InternalSignature,
+    verifying::VerifyingKey,
+    Signature,
+};
 
 /// ed25519 secret key as defined in [RFC8032 § 5.1.5]:
 ///
@@ -202,7 +204,9 @@ impl SigningKey {
     ///
     /// # Inputs
     ///
-    /// * `prehashed_message` is an instantiated SHA-512 digest of the message
+    /// * `prehashed_message` is an instantiated hash digest with 512-bits of
+    ///   output which has had the message to be signed previously fed into its
+    ///   state.
     /// * `context` is an optional context string, up to 255 bytes inclusive,
     ///   which may be used to provide additional domain separation.  If not
     ///   set, this will default to an empty string.
@@ -213,10 +217,10 @@ impl SigningKey {
     ///
     /// # Note
     ///
-    /// The RFC only permits SHA-512 to be used for prehashing. This function technically works,
-    /// and is probably safe to use, with any secure hash function with 512-bit digests, but
-    /// anything outside of SHA-512 is NOT specification-compliant. We expose [`crate::Sha512`] for
-    /// user convenience.
+    /// The RFC only permits SHA-512 to be used for prehashing, i.e., `MsgDigest = Sha512`. This
+    /// function technically works, and is probably safe to use, with any secure hash function with
+    /// 512-bit digests, but anything outside of SHA-512 is NOT specification-compliant. We expose
+    /// [`crate::Sha512`] for user convenience.
     ///
     /// # Examples
     ///
@@ -297,15 +301,15 @@ impl SigningKey {
     /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
     /// [terrible_idea]: https://github.com/isislovecruft/scripts/blob/master/gpgkey2bc.py
     #[cfg(feature = "digest")]
-    pub fn sign_prehashed<D>(
+    pub fn sign_prehashed<MsgDigest>(
         &self,
-        prehashed_message: D,
+        prehashed_message: MsgDigest,
         context: Option<&[u8]>,
     ) -> Result<Signature, SignatureError>
     where
-        D: Digest<OutputSize = U64>,
+        MsgDigest: Digest<OutputSize = U64>,
     {
-        ExpandedSecretKey::from(&self.secret_key).sign_prehashed(
+        ExpandedSecretKey::from(&self.secret_key).raw_sign_prehashed::<MsgDigest, Sha512>(
             prehashed_message,
             &self.verifying_key,
             context,
@@ -333,6 +337,13 @@ impl SigningKey {
     ///
     /// Returns `true` if the `signature` was a valid signature created by this
     /// [`SigningKey`] on the `prehashed_message`.
+    ///
+    /// # Note
+    ///
+    /// The RFC only permits SHA-512 to be used for prehashing, i.e., `MsgDigest = Sha512`. This
+    /// function technically works, and is probably safe to use, with any secure hash function with
+    /// 512-bit digests, but anything outside of SHA-512 is NOT specification-compliant. We expose
+    /// [`crate::Sha512`] for user convenience.
     ///
     /// # Examples
     ///
@@ -378,14 +389,14 @@ impl SigningKey {
     ///
     /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
     #[cfg(feature = "digest")]
-    pub fn verify_prehashed<D>(
+    pub fn verify_prehashed<MsgDigest>(
         &self,
-        prehashed_message: D,
+        prehashed_message: MsgDigest,
         context: Option<&[u8]>,
         signature: &Signature,
     ) -> Result<(), SignatureError>
     where
-        D: Digest<OutputSize = U64>,
+        MsgDigest: Digest<OutputSize = U64>,
     {
         self.verifying_key
             .verify_prehashed(prehashed_message, context, signature)
@@ -485,7 +496,7 @@ impl Signer<Signature> for SigningKey {
     /// Sign a message with this signing key's secret key.
     fn try_sign(&self, message: &[u8]) -> Result<Signature, SignatureError> {
         let expanded: ExpandedSecretKey = (&self.secret_key).into();
-        Ok(expanded.sign(message, &self.verifying_key))
+        Ok(expanded.raw_sign::<Sha512>(message, &self.verifying_key))
     }
 }
 
@@ -697,57 +708,9 @@ impl<'d> Deserialize<'d> for SigningKey {
     }
 }
 
-/// An "expanded" secret key.
-///
-/// This is produced by using an hash function with 512-bits output to digest a
-/// `SecretKey`.  The output digest is then split in half, the lower half being
-/// the actual `key` used to sign messages, after twiddling with some bits.¹ The
-/// upper half is used a sort of half-baked, ill-designed² pseudo-domain-separation
-/// prefix thing, which is used during signature production by
-/// concatenating it with the message to be signed before the message is hashed.
-///
-/// Instances of this secret are automatically overwritten with zeroes when they
-/// fall out of scope.
-//
-// ¹ This results in a slight bias towards non-uniformity at one spectrum of
-// the range of valid keys.  Oh well: not my idea; not my problem.
-//
-// ² It is the author's view (specifically, isis agora lovecruft, in the event
-// you'd like to complain about me, again) that this is "ill-designed" because
-// this doesn't actually provide true hash domain separation, in that in many
-// real-world applications a user wishes to have one key which is used in
-// several contexts (such as within tor, which does domain separation
-// manually by pre-concatenating static strings to messages to achieve more
-// robust domain separation).  In other real-world applications, such as
-// bitcoind, a user might wish to have one master keypair from which others are
-// derived (à la BIP32) and different domain separators between keys derived at
-// different levels (and similarly for tree-based key derivation constructions,
-// such as hash-based signatures).  Leaving the domain separation to
-// application designers, who thus far have produced incompatible,
-// slightly-differing, ad hoc domain separation (at least those application
-// designers who knew enough cryptographic theory to do so!), is therefore a
-// bad design choice on the part of the cryptographer designing primitives
-// which should be simple and as foolproof as possible to use for
-// non-cryptographers.  Further, later in the ed25519 signature scheme, as
-// specified in RFC8032, the public key is added into *another* hash digest
-// (along with the message, again); it is unclear to this author why there's
-// not only one but two poorly-thought-out attempts at domain separation in the
-// same signature scheme, and which both fail in exactly the same way.  For a
-// better-designed, Schnorr-based signature scheme, see Trevor Perrin's work on
-// "generalised EdDSA" and "VXEdDSA".
-pub(crate) struct ExpandedSecretKey {
-    pub(crate) scalar: Scalar,
-    pub(crate) hash_prefix: [u8; 32],
-}
-
-#[cfg(feature = "zeroize")]
-impl Drop for ExpandedSecretKey {
-    fn drop(&mut self) {
-        self.scalar.zeroize();
-        self.hash_prefix.zeroize()
-    }
-}
-
+/// The spec-compliant way to define an expanded secret key. This computes `SHA512(sk)`, clamps the
+/// first 32 bytes and uses it as a scalar, and uses the second 32 bytes as a domain separator for
+/// hashing.
 impl From<&SecretKey> for ExpandedSecretKey {
     #[allow(clippy::unwrap_used)]
     fn from(secret_key: &SecretKey) -> ExpandedSecretKey {
@@ -763,153 +726,116 @@ impl From<&SecretKey> for ExpandedSecretKey {
     }
 }
 
+//
+// Signing functions. These are pub(crate) so that the `hazmat` module can use them
+//
+
 impl ExpandedSecretKey {
-    /// Sign a message with this `ExpandedSecretKey`.
-    pub(crate) fn sign(&self, message: &[u8], verifying_key: &VerifyingKey) -> Signature {
-        private_raw_sign(self.scalar, self.hash_prefix, message, verifying_key)
+    /// The plain, non-prehashed, signing function for Ed25519. `SigDigest` is the digest used to
+    /// calculate the pseudorandomness needed for signing. According to the spec, `SigDigest =
+    /// Sha512`, and `self` is derived via the method defined in `impl From<&SigningKey> for
+    /// ExpandedSecretKey`.
+    ///
+    /// This definition is loose in its parameters so that end-users of the `hazmat` module can
+    /// change how the `ExpandedSecretKey` is calculated and which hash function to use.
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub(crate) fn raw_sign<SigDigest>(
+        &self,
+        message: &[u8],
+        verifying_key: &VerifyingKey,
+    ) -> Signature
+    where
+        SigDigest: Digest<OutputSize = U64>,
+    {
+        let mut h = SigDigest::new();
+
+        h.update(self.hash_prefix);
+        h.update(message);
+
+        let r = Scalar::from_hash(h);
+        let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
+
+        h = SigDigest::new();
+        h.update(R.as_bytes());
+        h.update(verifying_key.as_bytes());
+        h.update(message);
+
+        let k = Scalar::from_hash(h);
+        let s: Scalar = (k * self.scalar) + r;
+
+        InternalSignature { R, s }.into()
     }
 
-    /// Sign a `prehashed_message` with this `ExpandedSecretKey` using the
-    /// Ed25519ph algorithm defined in [RFC8032 §5.1][rfc8032].
+    /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `MsgDigest` is the digest
+    /// function used to hash the signed message. `SigDigest` is the digest function used to
+    /// calculate the pseudorandomness needed for signing. According to the spec, `MsgDigest =
+    /// SigDigest = Sha512`, and `self` is derived via the method defined in `impl
+    /// From<&SigningKey> for ExpandedSecretKey`.
     ///
-    /// # Inputs
-    ///
-    /// * `prehashed_message` is an instantiated hash digest with 512-bits of
-    ///   output which has had the message to be signed previously fed into its
-    ///   state.
-    /// * `verifying_key` is a [`VerifyingKey`] which corresponds to this secret key.
-    /// * `context` is an optional context string, up to 255 bytes inclusive,
-    ///   which may be used to provide additional domain separation.  If not
-    ///   set, this will default to an empty string.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` whose `Ok` value is an Ed25519ph [`Signature`] on the
-    /// `prehashed_message` if the context was 255 bytes or less, otherwise
-    /// a `SignatureError`.
-    ///
-    /// [rfc8032]: https://tools.ietf.org/html/rfc8032#section-5.1
+    /// This definition is loose in its parameters so that end-users of the `hazmat` module can
+    /// change how the `ExpandedSecretKey` is calculated and which `SigDigest` function to use.
     #[cfg(feature = "digest")]
-    pub(crate) fn sign_prehashed<'a, D>(
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub(crate) fn raw_sign_prehashed<'a, MsgDigest, SigDigest>(
         &self,
-        prehashed_message: D,
+        prehashed_message: MsgDigest,
         verifying_key: &VerifyingKey,
         context: Option<&'a [u8]>,
     ) -> Result<Signature, SignatureError>
     where
-        D: Digest<OutputSize = U64>,
+        MsgDigest: Digest<OutputSize = U64>,
+        SigDigest: Digest<OutputSize = U64>,
     {
-        private_raw_sign_prehashed(
-            self.scalar,
-            self.hash_prefix,
-            prehashed_message,
-            verifying_key,
-            context,
-        )
+        let mut prehash: [u8; 64] = [0u8; 64];
+
+        let ctx: &[u8] = context.unwrap_or(b""); // By default, the context is an empty string.
+
+        if ctx.len() > 255 {
+            return Err(SignatureError::from(InternalError::PrehashedContextLength));
+        }
+
+        let ctx_len: u8 = ctx.len() as u8;
+
+        // Get the result of the pre-hashed message.
+        prehash.copy_from_slice(prehashed_message.finalize().as_slice());
+
+        // This is the dumbest, ten-years-late, non-admission of fucking up the
+        // domain separation I have ever seen.  Why am I still required to put
+        // the upper half "prefix" of the hashed "secret key" in here?  Why
+        // can't the user just supply their own nonce and decide for themselves
+        // whether or not they want a deterministic signature scheme?  Why does
+        // the message go into what's ostensibly the signature domain separation
+        // hash?  Why wasn't there always a way to provide a context string?
+        //
+        // ...
+        //
+        // This is a really fucking stupid bandaid, and the damned scheme is
+        // still bleeding from malleability, for fuck's sake.
+        let mut h = SigDigest::new()
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update([1]) // Ed25519ph
+            .chain_update([ctx_len])
+            .chain_update(ctx)
+            .chain_update(self.hash_prefix)
+            .chain_update(&prehash[..]);
+
+        let r = Scalar::from_hash(h);
+        let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
+
+        h = SigDigest::new()
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update([1]) // Ed25519ph
+            .chain_update([ctx_len])
+            .chain_update(ctx)
+            .chain_update(R.as_bytes())
+            .chain_update(verifying_key.as_bytes())
+            .chain_update(&prehash[..]);
+
+        let k = Scalar::from_hash(h);
+        let s: Scalar = (k * self.scalar) + r;
+
+        Ok(InternalSignature { R, s }.into())
     }
-}
-
-//
-// Signing functions. These are pub(crate) so that the hazmat can use them
-//
-
-/// The plain, non-prehashed, signing function for Ed25519. `scalar` is the secret scalar of the
-/// signing key. `scalar and `hash_prefix` are usually selected such that that `scalar ||
-/// hash_prefix = H(sk)` where `sk` is the signing key.
-///
-/// See docs on `raw_sign()` for more detail.
-#[allow(non_snake_case)]
-#[inline(always)]
-pub(crate) fn private_raw_sign(
-    scalar: Scalar,
-    hash_prefix: [u8; 32],
-    message: &[u8],
-    verifying_key: &VerifyingKey,
-) -> Signature {
-    let mut h: Sha512 = Sha512::new();
-
-    h.update(hash_prefix);
-    h.update(message);
-
-    let r = Scalar::from_hash(h);
-    let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
-
-    h = Sha512::new();
-    h.update(R.as_bytes());
-    h.update(verifying_key.as_bytes());
-    h.update(message);
-
-    let k = Scalar::from_hash(h);
-    let s: Scalar = (k * scalar) + r;
-
-    InternalSignature { R, s }.into()
-}
-
-/// The prehashed signing function for Ed25519. `scalar` and `hash_prefix` are usually selected
-/// such that `scalar || hash_prefix = H(sk)` where `sk` is the signing key.
-///
-/// See docs on `raw_sign_prehashed()` for more detail.
-#[cfg(feature = "digest")]
-#[allow(non_snake_case)]
-#[inline(always)]
-pub(crate) fn private_raw_sign_prehashed<'a, D>(
-    scalar: Scalar,
-    hash_prefix: [u8; 32],
-    prehashed_message: D,
-    verifying_key: &VerifyingKey,
-    context: Option<&'a [u8]>,
-) -> Result<Signature, SignatureError>
-where
-    D: Digest<OutputSize = U64>,
-{
-    let mut h: Sha512;
-    let mut prehash: [u8; 64] = [0u8; 64];
-
-    let ctx: &[u8] = context.unwrap_or(b""); // By default, the context is an empty string.
-
-    if ctx.len() > 255 {
-        return Err(SignatureError::from(InternalError::PrehashedContextLength));
-    }
-
-    let ctx_len: u8 = ctx.len() as u8;
-
-    // Get the result of the pre-hashed message.
-    prehash.copy_from_slice(prehashed_message.finalize().as_slice());
-
-    // This is the dumbest, ten-years-late, non-admission of fucking up the
-    // domain separation I have ever seen.  Why am I still required to put
-    // the upper half "prefix" of the hashed "secret key" in here?  Why
-    // can't the user just supply their own nonce and decide for themselves
-    // whether or not they want a deterministic signature scheme?  Why does
-    // the message go into what's ostensibly the signature domain separation
-    // hash?  Why wasn't there always a way to provide a context string?
-    //
-    // ...
-    //
-    // This is a really fucking stupid bandaid, and the damned scheme is
-    // still bleeding from malleability, for fuck's sake.
-    h = Sha512::new()
-        .chain_update(b"SigEd25519 no Ed25519 collisions")
-        .chain_update([1]) // Ed25519ph
-        .chain_update([ctx_len])
-        .chain_update(ctx)
-        .chain_update(hash_prefix)
-        .chain_update(&prehash[..]);
-
-    let r = Scalar::from_hash(h);
-    let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
-
-    h = Sha512::new()
-        .chain_update(b"SigEd25519 no Ed25519 collisions")
-        .chain_update([1]) // Ed25519ph
-        .chain_update([ctx_len])
-        .chain_update(ctx)
-        .chain_update(R.as_bytes())
-        .chain_update(verifying_key.as_bytes())
-        .chain_update(&prehash[..]);
-
-    let k = Scalar::from_hash(h);
-    let s: Scalar = (k * scalar) + r;
-
-    Ok(InternalSignature { R, s }.into())
 }

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -100,6 +100,15 @@ impl From<&SigningKey> for VerifyingKey {
     }
 }
 
+impl From<EdwardsPoint> for VerifyingKey {
+    fn from(point: EdwardsPoint) -> VerifyingKey {
+        VerifyingKey {
+            point,
+            compressed: point.compress(),
+        }
+    }
+}
+
 impl VerifyingKey {
     /// Convert this public key to a byte array.
     #[inline]

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -13,10 +13,8 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 
-#[cfg(feature = "digest")]
-use curve25519_dalek::digest::generic_array::typenum::U64;
 use curve25519_dalek::{
-    digest::Digest,
+    digest::{generic_array::typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     montgomery::MontgomeryPoint,
     scalar::Scalar,

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -13,8 +13,10 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 
+#[cfg(feature = "digest")]
+use curve25519_dalek::digest::generic_array::typenum::U64;
 use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
+    digest::Digest,
     edwards::{CompressedEdwardsY, EdwardsPoint},
     montgomery::MontgomeryPoint,
     scalar::Scalar,

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -268,7 +268,7 @@ impl VerifyingKey {
     {
         let signature = InternalSignature::try_from(signature)?;
 
-        let expected_R = self.recompute_R::<Sha512>(None, &signature, message);
+        let expected_R = self.recompute_R::<CtxDigest>(None, &signature, message);
         if expected_R == signature.R {
             Ok(())
         } else {
@@ -277,23 +277,23 @@ impl VerifyingKey {
     }
 
     /// The prehashed non-batched Ed25519 verification check, rejecting non-canonical R values.
-    /// (see [`Self::recompute_R`]). `MsgDigest` is the digest used to hash the signed message.
-    /// `CtxDigest` is the digest used to calculate the pseudorandomness needed for signing.
-    /// According to the spec, `MsgDigest = CtxDigest = Sha512`.
+    /// (see [`Self::recompute_R`]). `CtxDigest` is the digest used to calculate the
+    /// pseudorandomness needed for signing. `MsgDigest` is the digest used to hash the signed
+    /// message. According to the spec, `MsgDigest = CtxDigest = Sha512`.
     ///
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
     /// change how the `ExpandedSecretKey` is calculated and which hash function to use.
     #[cfg(feature = "digest")]
     #[allow(non_snake_case)]
-    pub(crate) fn raw_verify_prehashed<MsgDigest, CtxDigest>(
+    pub(crate) fn raw_verify_prehashed<CtxDigest, MsgDigest>(
         &self,
         prehashed_message: MsgDigest,
         context: Option<&[u8]>,
         signature: &ed25519::Signature,
     ) -> Result<(), SignatureError>
     where
-        MsgDigest: Digest<OutputSize = U64>,
         CtxDigest: Digest<OutputSize = U64>,
+        MsgDigest: Digest<OutputSize = U64>,
     {
         let signature = InternalSignature::try_from(signature)?;
 
@@ -347,7 +347,7 @@ impl VerifyingKey {
     where
         MsgDigest: Digest<OutputSize = U64>,
     {
-        self.raw_verify_prehashed::<MsgDigest, Sha512>(prehashed_message, context, signature)
+        self.raw_verify_prehashed::<Sha512, MsgDigest>(prehashed_message, context, signature)
     }
 
     /// Strictly verify a signature on a message with this keypair's public key.


### PR DESCRIPTION
This splits out the signing functionality we have into two new functions. Nothing changes underlyingly. The only difference is now users can use `raw_sign()` and `raw_sign_prehashed()` if you enable the `raw_sign` feature (and `digest` feature as well for the latter).

Also this renames `ExpandedSecretKey::nonce` to `hash_prefix`, because that's what it is, and it is absolutely used more than once.

Fixes #298.

# Why expose these functions

Our removal of the public `ExpandedSecretKey` API in  #205 made it impossible for users to sign using an `ExpandedSecretKey`. The only way to sign now is `SigningKey::sign`. The issue here is that some downstream users, as noted in #298, never actually saved their `SigningKey`, and only saved the `ExpandedSecretKey`. You cannot recover a `SigningKey` from an `ExpandedSecretKey`, since the former is the seed whose hash is expanded to the latter. Thus, it is necessary to expose some lower-level way of computing signatures. There were a few levels of abstraction we could have picked here, and I'm open to suggestions.

Separately, and I don't know how important this is, but these functions would allow someone to build [BIP32-Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) on top of this library, since `scalar` and `hash_prefix` are explicit inputs to the `raw_sign()` function.