### PR TITLE
Add `SigningKey::as_bytes`

### DIFF
--- a/src/signing.rs
+++ b/src/signing.rs
@@ -109,6 +109,12 @@ impl SigningKey {
         self.secret_key
     }
 
+    /// Convert this [`SigningKey`] into a [`SecretKey`] reference
+    #[inline]
+    pub fn as_bytes(&self) -> &SecretKey {
+        &self.secret_key
+    }
+
     /// Construct a [`SigningKey`] from the bytes of a `VerifyingKey` and `SecretKey`.
     ///
     /// # Inputs


### PR DESCRIPTION
Allows to get a reference to the secret bytes without making a copy.