### PR TITLE
Fix variable names in the invariant description

### DIFF
--- a/src/signing.rs
+++ b/src/signing.rs
@@ -54,8 +54,9 @@ use crate::{
 pub type SecretKey = [u8; SECRET_KEY_LENGTH];
 
 /// ed25519 signing key which can be used to produce signatures.
-// Invariant: `public` is always the public key of `secret`. This prevents the signing function
-// oracle attack described in https://github.com/MystenLabs/ed25519-unsafe-libs
+// Invariant: `verifying_key` is always the public key of
+// `secret_key`. This prevents the signing function oracle attack
+// described in https://github.com/MystenLabs/ed25519-unsafe-libs
 #[derive(Clone, Debug)]
 pub struct SigningKey {
     /// The secret half of this signing key.


### PR DESCRIPTION
Previously the variable names referred to `public` and `secret` which do not exist. Update them to `verifying_key` and `secret_key`.